### PR TITLE
fix cursor.json file permissions

### DIFF
--- a/blockpoller/state_file.go
+++ b/blockpoller/state_file.go
@@ -79,7 +79,7 @@ func (p *BlockPoller) saveState(blocks []*forkable.Block) error {
 	}
 	fpath := filepath.Join(p.stateStorePath, "cursor.json")
 
-	if err := os.WriteFile(fpath, cnt, os.ModePerm); err != nil {
+	if err := os.WriteFile(fpath, cnt, 0666); err != nil {
 		return fmt.Errorf("unable to open cursor file %s: %w", fpath, err)
 	}
 


### PR DESCRIPTION
currently the cursor.json file is written with the execute bit set (0777). This sets it to 0666 which is the default for non-executable files