### PR TITLE
fix: reader-node-stdin not shutting down when receiving an EOF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Operators, you should copy/paste content of this content straight to your projec
 
 If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you should copy the content between those 2 version to your own repository, replacing placeholder value `fire{chain}` with your chain's own binary.
 
+## Unreleased
+
+* fix: reader-node-stdin not shutting down after receiving an EOF
+
 ## v1.6.2
 
 ### Core

--- a/node-manager/app/node_reader_stdin/app.go
+++ b/node-manager/app/node_reader_stdin/app.go
@@ -158,6 +158,7 @@ func (a *App) Run() error {
 		}
 
 		a.zlogger.Info("done reading from stdin")
+		mindreaderLogPlugin.Shutdown(nil)
 	}()
 
 	return nil


### PR DESCRIPTION
In case the pipe to the reader-node-stdin is closed (for example due to the blockchain node crashing), the reader-node-stdin would just continue running forever. This adds a shutdown for such cases.