### PR TITLE
Refactored how `firecore tools` handles printing

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -325,6 +325,13 @@ func (c *Chain[B]) LoggerPackageID(subPackage string) string {
 	return fmt.Sprintf("%s/%s", c.FullyQualifiedModule, subPackage)
 }
 
+// BlockFileDescriptor returns the `protoreflect.FileDescriptor` of the chain's block
+// extracted from the block factory defined on the chain. This would resolve for example
+// to Proto file descriptor `sf/ethereum/type/v2/type.proto` for Ethereum.
+func (c *Chain[B]) BlockFileDescriptor() protoreflect.FileDescriptor {
+	return c.BlockFactory().ProtoReflect().Descriptor().ParentFile()
+}
+
 // VersionString computes the version string that will be display when calling `firexxx --version`
 // and extract build information from Git via Golang `debug.ReadBuildInfo`.
 func (c *Chain[B]) VersionString() string {

--- a/cmd/tools/check/check.go
+++ b/cmd/tools/check/check.go
@@ -31,7 +31,12 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-func NewCheckCommand[B firecore.Block](chain *firecore.Chain[B], rootLog *zap.Logger) *cobra.Command {
+// Super hackish way to get the *cobra.command needed for sflags call but where
+// CheckMergedBlocks public method doesn't receive the *cobra.Command
+var globalToolsCheckCmd *cobra.Command
+
+func NewCheckCommand[B firecore.Block](chain *firecore.Chain[B], rootLog *zap.Logger) (out *cobra.Command) {
+	defer func() { globalToolsCheckCmd = out }()
 
 	toolsCheckCmd := &cobra.Command{Use: "check", Short: "Various checks for deployment, data integrity & debugging"}
 

--- a/cmd/tools/compare/tools_compare_blocks.go
+++ b/cmd/tools/compare/tools_compare_blocks.go
@@ -30,7 +30,7 @@ import (
 	"github.com/streamingfast/dstore"
 	firecore "github.com/streamingfast/firehose-core"
 	"github.com/streamingfast/firehose-core/cmd/tools/check"
-	"github.com/streamingfast/firehose-core/json"
+	fcjson "github.com/streamingfast/firehose-core/json"
 	fcproto "github.com/streamingfast/firehose-core/proto"
 	"github.com/streamingfast/firehose-core/types"
 	"go.uber.org/multierr"
@@ -361,16 +361,16 @@ func Compare(reference proto.Message, current proto.Message, includeUnknownField
 
 	//todo: check if there is a equals that do not compare unknown fields
 	if !proto.Equal(reference, current) {
-		var opts []json.MarshallerOption
+		var opts []fcjson.MarshallerOption
 		if !includeUnknownFields {
-			opts = append(opts, json.WithoutUnknownFields())
+			opts = append(opts, fcjson.WithoutUnknownFields())
 		}
 
-		if bytesEncoding == "base58" {
-			opts = append(opts, json.WithBytesEncoderFunc(json.ToBase58))
+		if bytesEncoding != "" {
+			opts = append(opts, fcjson.WithBytesEncoding(bytesEncoding))
 		}
 
-		encoder := json.NewMarshaller(registry, opts...)
+		encoder := fcjson.NewMarshaller(registry, opts...)
 
 		referenceAsJSON, err := encoder.MarshalToString(reference)
 		cli.NoError(err, "marshal JSON reference")

--- a/cmd/tools/compare/tools_compare_blocks.go
+++ b/cmd/tools/compare/tools_compare_blocks.go
@@ -73,9 +73,7 @@ func NewToolsCompareBlocksCmd[B firecore.Block](chain *firecore.Chain[B]) *cobra
 
 	flags := cmd.PersistentFlags()
 	flags.Bool("diff", false, "When activated, difference is displayed for each block with a difference")
-	flags.String("bytes-encoding", "hex", "Encoding for bytes fields, either 'hex' or 'base58'")
 	flags.Bool("include-unknown-fields", false, "When activated, the 'unknown fields' in the protobuf message will also be compared. These would not generate any difference when unmarshalled with the current protobuf definition.")
-	flags.StringSlice("proto-paths", []string{""}, "Paths to proto files to use for dynamic decoding of blocks")
 
 	return cmd
 }

--- a/cmd/tools/print/printer.go
+++ b/cmd/tools/print/printer.go
@@ -1,0 +1,131 @@
+// Copyright 2021 dfuse Platform Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package print
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"unsafe"
+
+	"github.com/spf13/cobra"
+	"github.com/streamingfast/cli/sflags"
+	fcproto "github.com/streamingfast/firehose-core/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func GetOutputPrinter(cmd *cobra.Command, chainFileDescriptor protoreflect.FileDescriptor) (OutputPrinter, error) {
+	printer := sflags.MustGetString(cmd, "output")
+	if printer == "" {
+		printer = "jsonl"
+	}
+
+	var protoPaths []string
+	if sflags.FlagDefined(cmd, "proto-paths") {
+		protoPaths = sflags.MustGetStringSlice(cmd, "proto-paths")
+	}
+
+	bytesEncoding := "hex"
+	if sflags.FlagDefined(cmd, "bytes-encoding") {
+		bytesEncoding = sflags.MustGetString(cmd, "bytes-encoding")
+	}
+
+	registry, err := fcproto.NewRegistry(chainFileDescriptor, protoPaths...)
+	if err != nil {
+		return nil, fmt.Errorf("new registry: %w", err)
+	}
+
+	if printer == "json" || printer == "jsonl" {
+		jsonPrinter, err := NewJSONOutputPrinter(bytesEncoding, printer == "jsonl", registry)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create json encoder: %w", err)
+		}
+
+		return jsonPrinter, nil
+	}
+
+	if printer == "protojson" || printer == "protojsonl" {
+		indent := ""
+		if printer == "protojson" {
+			indent = "  "
+		}
+
+		return NewProtoJSONOutputPrinter(indent, registry), nil
+	}
+
+	if printer == "text" {
+		// Supports the `transactions` flag defined on `firecore tools print` sub-command,
+		// we should move it to a proper `text` sub-option like `output-text-details` or something
+		// like that.
+		printTransactions := false
+		if sflags.FlagDefined(cmd, "transactions") {
+			printTransactions = sflags.MustGetBool(cmd, "transactions")
+		}
+
+		return NewTextOutputPrinter(bytesEncoding, registry, printTransactions), nil
+	}
+
+	return nil, fmt.Errorf("unsupported output printer %q", printer)
+}
+
+//go:generate go-enum -f=$GOFILE --marshal --names --nocase
+
+// ENUM(Text, JSON, JSONL, ProtoJSON, ProtoJSONL)
+type PrintOutputMode uint
+
+type OutputPrinter interface {
+	PrintTo(message any, w io.Writer) error
+}
+
+func writeStringToWriter(w io.Writer, str string) error {
+	return writeBytesToWriter(w, unsafe.Slice(unsafe.StringData(str), len(str)))
+}
+
+func writeStringFToWriter(w io.Writer, format string, args ...any) error {
+	return writeStringToWriter(w, fmt.Sprintf(format, args...))
+}
+
+func writeBytesToWriter(w io.Writer, data []byte) error {
+	n, err := w.Write(data)
+	if err != nil {
+		return err
+	}
+
+	if n != len(data) {
+		return io.ErrShortWrite
+	}
+
+	return nil
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func deref[T any](v *T, orDefault T) T {
+	if v == nil {
+		return orDefault
+	}
+
+	return *v
+}
+
+func uint64PtrToString(v *uint64, orDefault string) string {
+	if v == nil {
+		return orDefault
+	}
+
+	return strconv.FormatUint(*v, 10)
+}

--- a/cmd/tools/print/printer_enum.go
+++ b/cmd/tools/print/printer_enum.go
@@ -18,16 +18,22 @@ const (
 	PrintOutputModeJSON
 	// PrintOutputModeJSONL is a PrintOutputMode of type JSONL.
 	PrintOutputModeJSONL
+	// PrintOutputModeProtoJSON is a PrintOutputMode of type ProtoJSON.
+	PrintOutputModeProtoJSON
+	// PrintOutputModeProtoJSONL is a PrintOutputMode of type ProtoJSONL.
+	PrintOutputModeProtoJSONL
 )
 
 var ErrInvalidPrintOutputMode = fmt.Errorf("not a valid PrintOutputMode, try [%s]", strings.Join(_PrintOutputModeNames, ", "))
 
-const _PrintOutputModeName = "TextJSONJSONL"
+const _PrintOutputModeName = "TextJSONJSONLProtoJSONProtoJSONL"
 
 var _PrintOutputModeNames = []string{
 	_PrintOutputModeName[0:4],
 	_PrintOutputModeName[4:8],
 	_PrintOutputModeName[8:13],
+	_PrintOutputModeName[13:22],
+	_PrintOutputModeName[22:32],
 }
 
 // PrintOutputModeNames returns a list of possible string values of PrintOutputMode.
@@ -38,9 +44,11 @@ func PrintOutputModeNames() []string {
 }
 
 var _PrintOutputModeMap = map[PrintOutputMode]string{
-	PrintOutputModeText:  _PrintOutputModeName[0:4],
-	PrintOutputModeJSON:  _PrintOutputModeName[4:8],
-	PrintOutputModeJSONL: _PrintOutputModeName[8:13],
+	PrintOutputModeText:       _PrintOutputModeName[0:4],
+	PrintOutputModeJSON:       _PrintOutputModeName[4:8],
+	PrintOutputModeJSONL:      _PrintOutputModeName[8:13],
+	PrintOutputModeProtoJSON:  _PrintOutputModeName[13:22],
+	PrintOutputModeProtoJSONL: _PrintOutputModeName[22:32],
 }
 
 // String implements the Stringer interface.
@@ -59,12 +67,16 @@ func (x PrintOutputMode) IsValid() bool {
 }
 
 var _PrintOutputModeValue = map[string]PrintOutputMode{
-	_PrintOutputModeName[0:4]:                   PrintOutputModeText,
-	strings.ToLower(_PrintOutputModeName[0:4]):  PrintOutputModeText,
-	_PrintOutputModeName[4:8]:                   PrintOutputModeJSON,
-	strings.ToLower(_PrintOutputModeName[4:8]):  PrintOutputModeJSON,
-	_PrintOutputModeName[8:13]:                  PrintOutputModeJSONL,
-	strings.ToLower(_PrintOutputModeName[8:13]): PrintOutputModeJSONL,
+	_PrintOutputModeName[0:4]:                    PrintOutputModeText,
+	strings.ToLower(_PrintOutputModeName[0:4]):   PrintOutputModeText,
+	_PrintOutputModeName[4:8]:                    PrintOutputModeJSON,
+	strings.ToLower(_PrintOutputModeName[4:8]):   PrintOutputModeJSON,
+	_PrintOutputModeName[8:13]:                   PrintOutputModeJSONL,
+	strings.ToLower(_PrintOutputModeName[8:13]):  PrintOutputModeJSONL,
+	_PrintOutputModeName[13:22]:                  PrintOutputModeProtoJSON,
+	strings.ToLower(_PrintOutputModeName[13:22]): PrintOutputModeProtoJSON,
+	_PrintOutputModeName[22:32]:                  PrintOutputModeProtoJSONL,
+	strings.ToLower(_PrintOutputModeName[22:32]): PrintOutputModeProtoJSONL,
 }
 
 // ParsePrintOutputMode attempts to convert a string to a PrintOutputMode.

--- a/cmd/tools/print/printer_json.go
+++ b/cmd/tools/print/printer_json.go
@@ -1,0 +1,63 @@
+// Copyright 2021 dfuse Platform Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package print
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/go-json-experiment/json"
+	"github.com/go-json-experiment/json/jsontext"
+	fcjson "github.com/streamingfast/firehose-core/json"
+	fcproto "github.com/streamingfast/firehose-core/proto"
+)
+
+var _ OutputPrinter = (*JSONOutputPrinter)(nil)
+
+type JSONOutputPrinter struct {
+	singleLine bool
+	marshaller *fcjson.Marshaller
+}
+
+func NewJSONOutputPrinter(bytesEncoding string, singleLine bool, registry *fcproto.Registry) (OutputPrinter, error) {
+	var options []fcjson.MarshallerOption
+
+	if bytesEncoding == "base58" {
+		options = append(options, fcjson.WithBytesEncoderFunc(fcjson.ToBase58))
+	}
+
+	if bytesEncoding == "base64" {
+		options = append(options, fcjson.WithBytesEncoderFunc(fcjson.ToBase64))
+	}
+
+	return &JSONOutputPrinter{
+		singleLine: singleLine,
+		marshaller: fcjson.NewMarshaller(registry, options...),
+	}, nil
+}
+
+func (p *JSONOutputPrinter) PrintTo(input any, w io.Writer) error {
+	var encoderOptions []json.Options
+	if !p.singleLine {
+		encoderOptions = append(encoderOptions, jsontext.WithIndent("  "))
+	}
+
+	out, err := p.marshaller.MarshalToString(input, encoderOptions...)
+	if err != nil {
+		return fmt.Errorf("marshalling block to json: %w", err)
+	}
+
+	return writeStringToWriter(w, out)
+}

--- a/cmd/tools/print/printer_json.go
+++ b/cmd/tools/print/printer_json.go
@@ -34,12 +34,8 @@ type JSONOutputPrinter struct {
 func NewJSONOutputPrinter(bytesEncoding string, singleLine bool, registry *fcproto.Registry) (OutputPrinter, error) {
 	var options []fcjson.MarshallerOption
 
-	if bytesEncoding == "base58" {
-		options = append(options, fcjson.WithBytesEncoderFunc(fcjson.ToBase58))
-	}
-
-	if bytesEncoding == "base64" {
-		options = append(options, fcjson.WithBytesEncoderFunc(fcjson.ToBase64))
+	if bytesEncoding != "" {
+		options = append(options, fcjson.WithBytesEncoding(bytesEncoding))
 	}
 
 	return &JSONOutputPrinter{

--- a/cmd/tools/print/printer_protojson.go
+++ b/cmd/tools/print/printer_protojson.go
@@ -1,0 +1,54 @@
+// Copyright 2021 dfuse Platform Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package print
+
+import (
+	"fmt"
+	"io"
+
+	fcproto "github.com/streamingfast/firehose-core/proto"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+var _ OutputPrinter = (*ProtoJSONOutputPrinter)(nil)
+
+type ProtoJSONOutputPrinter struct {
+	marshaller protojson.MarshalOptions
+}
+
+func NewProtoJSONOutputPrinter(indent string, registry *fcproto.Registry) *ProtoJSONOutputPrinter {
+	return &ProtoJSONOutputPrinter{
+		marshaller: protojson.MarshalOptions{
+			Resolver:          registry,
+			Indent:            indent,
+			EmitDefaultValues: true,
+		},
+	}
+}
+
+func (p *ProtoJSONOutputPrinter) PrintTo(input any, w io.Writer) error {
+	v, ok := input.(proto.Message)
+	if !ok {
+		return fmt.Errorf("we accept only proto.Message input")
+	}
+
+	out, err := p.marshaller.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshalling block to protojson: %w", err)
+	}
+
+	return writeBytesToWriter(w, out)
+}

--- a/cmd/tools/print/printer_text.go
+++ b/cmd/tools/print/printer_text.go
@@ -1,0 +1,254 @@
+// Copyright 2021 dfuse Platform Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package print
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strconv"
+	"strings"
+
+	pbbstream "github.com/streamingfast/bstream/pb/sf/bstream/v1"
+	fcjson "github.com/streamingfast/firehose-core/json"
+	fcproto "github.com/streamingfast/firehose-core/proto"
+	pbfirehose "github.com/streamingfast/pbgo/sf/firehose/v2"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+var _ OutputPrinter = (*TextOutputPrinter)(nil)
+
+type TextOutputPrinter struct {
+	bytesEncoding     string
+	registry          *fcproto.Registry
+	printTransactions bool
+}
+
+func NewTextOutputPrinter(bytesEncoding string, registry *fcproto.Registry, printTransactions bool) *TextOutputPrinter {
+	return &TextOutputPrinter{
+		bytesEncoding:     strings.ToLower(bytesEncoding),
+		registry:          registry,
+		printTransactions: printTransactions,
+	}
+}
+
+func (p *TextOutputPrinter) PrintTo(input any, out io.Writer) error {
+	if pbblock, ok := input.(*pbbstream.Block); ok {
+		err := writeStringFToWriter(out, "Block #%d (%s)\n - Parent: #%d (%s)\n  - LIB: #%d\n  - Time: %s\n",
+			pbblock.Number,
+			pbblock.Id,
+			pbblock.ParentNum,
+			pbblock.ParentId,
+			pbblock.LibNum,
+			pbblock.Timestamp.AsTime(),
+		)
+		if err != nil {
+			return fmt.Errorf("writing block: %w", err)
+		}
+
+		if p.printTransactions {
+			if _, err = out.Write([]byte("warning: transaction printing not supported by bstream block")); err != nil {
+				return fmt.Errorf("writing transaction support warning: %w", err)
+			}
+		}
+	}
+
+	if v, ok := input.(*pbfirehose.Response); ok {
+		return p.printBlock(v.Block, out)
+	}
+
+	if v, ok := input.(*pbfirehose.SingleBlockResponse); ok {
+		return p.printBlock(v.Block, out)
+	}
+
+	if v, ok := input.(proto.Message); ok {
+		return p.printGenericMessage(v, "unhandled message type", out)
+	}
+
+	return writeStringFToWriter(out, "%T", input)
+}
+
+func (p *TextOutputPrinter) printBlock(anyBlock *anypb.Any, out io.Writer) error {
+	block, err := anypb.UnmarshalNew(anyBlock, proto.UnmarshalOptions{Resolver: p.registry})
+	if err != nil {
+		if errors.Is(err, protoregistry.NotFound) {
+			return writeStringFToWriter(out, "Protobuf %s (not found in registry)", getAnyTypeID(anyBlock))
+		}
+
+		return fmt.Errorf("unmarshalling block: %w", err)
+	}
+
+	var hash, parentHash, libHash *string
+	var number, parentNumber, libNumber *uint64
+
+	// FIXME: Add timestamp
+	var fieldsExtractor func(message protoreflect.Message)
+	fieldsExtractor = func(message protoreflect.Message) {
+		fields := message.Descriptor().Fields()
+		for i := 0; i < fields.Len(); i++ {
+			field := fields.Get(i)
+			fieldName := field.Name()
+
+			switch {
+			case isField(fieldName, blockHashFields):
+				hash = p.extractHashFromField(field, message)
+			case isField(fieldName, parentBlockHashFields):
+				parentHash = p.extractHashFromField(field, message)
+			case isField(fieldName, libBlockHashFields):
+				libHash = p.extractHashFromField(field, message)
+
+			case isField(fieldName, blockNumberFields):
+				number = p.extractNumberFromField(field, message)
+			case isField(fieldName, parentBlockNumberFields):
+				parentNumber = p.extractNumberFromField(field, message)
+			case isField(fieldName, libBlockNumberFields):
+				libNumber = p.extractNumberFromField(field, message)
+
+			case isField(fieldName, blockHeaderFields) && field.Kind() == protoreflect.MessageKind:
+				fieldsExtractor(message.Get(field).Message())
+			}
+		}
+	}
+
+	fieldsExtractor(block.ProtoReflect())
+
+	var parts []string
+	if number != nil || hash != nil {
+		parts = append(parts, fmt.Sprintf("Block #%s (%s)", uint64PtrToString(number, "N/A"), deref(hash, "N/A")))
+	}
+
+	if parentNumber != nil || parentHash != nil {
+		parentNumberValue := "N/A"
+		if parentNumber != nil {
+			parentNumberValue = strconv.FormatUint(*parentNumber, 10)
+		} else if number != nil {
+			parentNumberValue = maybeDeriveParentNumber(block, *number)
+		}
+
+		parts = append(parts, fmt.Sprintf("Parent #%s (%s)", parentNumberValue, deref(parentHash, "N/A")))
+	}
+
+	if libNumber != nil || libHash != nil {
+		parts = append(parts, fmt.Sprintf("LIB #%s (%s)", uint64PtrToString(libNumber, "N/A"), deref(libHash, "N/A")))
+	}
+
+	if len(parts) > 0 {
+		if _, err := out.Write([]byte(strings.Join(parts, ", "))); err != nil {
+			return fmt.Errorf("writing block parts: %w", err)
+		}
+
+		return nil
+	}
+
+	return p.printGenericMessage(block, "unable to extract any block info", out)
+}
+
+func (p *TextOutputPrinter) extractHashFromField(field protoreflect.FieldDescriptor, message protoreflect.Message) *string {
+	if field.Kind() == protoreflect.StringKind {
+		return ptr(message.Get(field).String())
+	}
+
+	if field.Kind() == protoreflect.BytesKind {
+		bytes := message.Get(field).Bytes()
+		return ptr(fcjson.Encode(p.bytesEncoding, bytes))
+	}
+
+	value := message.Get(field)
+	if !value.IsValid() {
+		return ptr("<nil>")
+	}
+
+	return ptr(value.String())
+}
+
+func (p *TextOutputPrinter) extractNumberFromField(field protoreflect.FieldDescriptor, message protoreflect.Message) *uint64 {
+	kind := field.Kind()
+	if kind == protoreflect.Uint64Kind || kind == protoreflect.Uint32Kind || kind == protoreflect.Fixed64Kind || kind == protoreflect.Fixed32Kind {
+		return ptr(message.Get(field).Uint())
+	}
+
+	if kind == protoreflect.Int64Kind || kind == protoreflect.Int32Kind || kind == protoreflect.Sfixed32Kind || kind == protoreflect.Sfixed64Kind || kind == protoreflect.Sint32Kind || kind == protoreflect.Sint64Kind {
+		return ptr(uint64(message.Get(field).Int()))
+	}
+
+	return nil
+}
+
+func (p *TextOutputPrinter) printGenericMessage(message proto.Message, suffix string, out io.Writer) error {
+	format := "Protobuf %s"
+	args := []any{message.ProtoReflect().Descriptor().FullName()}
+
+	if suffix != "" {
+		format += " (%s)"
+		args = append(args, suffix)
+	}
+
+	return writeStringFToWriter(out, format, args...)
+}
+
+var blockHashFields = []string{"hash", "id", "block_hash", "blockhash"}
+var blockNumberFields = []string{
+	"number", "block_number", "blocknumber",
+	"num", "block_num", "blocknum",
+}
+
+var parentBlockNumberFields = []string{
+	"parent_number", "parentnumber",
+	"parent_block_number", "parentblocknumber",
+	"parent_num", "parent_num",
+	"parent_block_num", "parent_blocknum",
+}
+var parentBlockHashFields = []string{
+	"parent_hash", "parenthash", "parent_block_hash", "parentblockhash",
+	"previous_hash", "previoushash", "previous_block_hash", "previousblockhash",
+	"parent_id", "parentid",
+}
+
+var libBlockHashFields = []string{
+	"final_hash", "finalhash",
+	"lib_hash", "libblockhash",
+}
+var libBlockNumberFields = []string{
+	"final_number", "finalnumber",
+	"lib_number", "lib_hash",
+}
+
+var blockHeaderFields = []string{
+	"header", "block_header", "blockheader",
+}
+
+func isField(fieldShortName protoreflect.Name, candidates []string) bool {
+	return slices.Contains(candidates, strings.ToLower(string(fieldShortName)))
+}
+
+func maybeDeriveParentNumber(block protoreflect.ProtoMessage, field uint64) string {
+	if strings.Contains(string(block.ProtoReflect().Descriptor().FullName()), "sf.ethereum") {
+		if field == 0 {
+			return "None"
+		}
+
+		return strconv.FormatUint(field-1, 10)
+	}
+
+	return "N/A"
+}
+
+func getAnyTypeID(value *anypb.Any) string {
+	return strings.ReplaceAll(value.GetTypeUrl(), "type.googleapis.com/", "")
+}

--- a/json/marshallers.go
+++ b/json/marshallers.go
@@ -26,11 +26,13 @@ type kv struct {
 	value any
 }
 
+type CustomEncoderFunc func(encoder *jsontext.Encoder, t []byte, options json.Options) error
+
 type Marshaller struct {
 	marshallers          *json.Marshalers
 	includeUnknownFields bool
 	registry             *proto.Registry
-	bytesEncoderFunc     func(encoder *jsontext.Encoder, t []byte, options json.Options) error
+	bytesEncoderFunc     CustomEncoderFunc
 }
 
 type MarshallerOption func(*Marshaller)
@@ -40,7 +42,15 @@ func WithoutUnknownFields() MarshallerOption {
 		e.includeUnknownFields = false
 	}
 }
-func WithBytesEncoderFunc(f func(encoder *jsontext.Encoder, t []byte, options json.Options) error) MarshallerOption {
+
+func WithBytesEncoding(bytesEncoding string) MarshallerOption {
+	return withBytesEncoderFunc(jsonEncoder(bytesEncoding))
+}
+
+// Deprecated: Use WithBytesEncoding instead passing the encoding directly.
+var WithBytesEncoderFunc = withBytesEncoderFunc
+
+func withBytesEncoderFunc(f CustomEncoderFunc) MarshallerOption {
 	return func(e *Marshaller) {
 		e.bytesEncoderFunc = f
 	}
@@ -125,8 +135,7 @@ func (m *Marshaller) dynamicpbMessage(encoder *jsontext.Encoder, msg *dynamicpb.
 		x := msg.GetUnknown()
 		fieldNumber, ofType, l := protowire.ConsumeField(x)
 		if l > 0 {
-			var unknownValue []byte
-			unknownValue = x[:l]
+			unknownValue := x[:l]
 			kvl = append(kvl, &kv{
 				key:   fmt.Sprintf("__unknown_fields_%d_with_type_%d__", fieldNumber, ofType),
 				value: hex.EncodeToString(unknownValue),
@@ -213,15 +222,36 @@ func EncodeHex(bytes []byte) string {
 
 // Encode encodes the given bytes using the specified encoding.
 func Encode(bytesEncoding string, bytes []byte) string {
+	return Encoder(bytesEncoding)(bytes)
+}
+
+// Encoder returns the encoder function that will converts received bytes
+// into a string of the specified encoding.
+func Encoder(bytesEncoding string) func([]byte) string {
 	switch {
 	case strings.EqualFold(bytesEncoding, "base58"):
-		return base58.Encode(bytes)
+		return base58.Encode
 
 	case strings.EqualFold(bytesEncoding, "base64"):
-		return base64.StdEncoding.EncodeToString(bytes)
+		return base64.StdEncoding.EncodeToString
 
 	case strings.EqualFold(bytesEncoding, "hex"):
-		return hex.EncodeToString(bytes)
+		return hex.EncodeToString
+	}
+
+	panic(fmt.Errorf("unsupported bytes encoding: %s", bytesEncoding))
+}
+
+func jsonEncoder(bytesEncoding string) jsonEncoderFunc {
+	switch {
+	case strings.EqualFold(bytesEncoding, "base58"):
+		return ToBase58
+
+	case strings.EqualFold(bytesEncoding, "base64"):
+		return ToBase64
+
+	case strings.EqualFold(bytesEncoding, "hex"):
+		return ToHex
 	}
 
 	panic(fmt.Errorf("unsupported bytes encoding: %s", bytesEncoding))

--- a/json/marshallers.go
+++ b/json/marshallers.go
@@ -242,7 +242,7 @@ func Encoder(bytesEncoding string) func([]byte) string {
 	panic(fmt.Errorf("unsupported bytes encoding: %s", bytesEncoding))
 }
 
-func jsonEncoder(bytesEncoding string) jsonEncoderFunc {
+func jsonEncoder(bytesEncoding string) CustomEncoderFunc {
 	switch {
 	case strings.EqualFold(bytesEncoding, "base58"):
 		return ToBase58

--- a/json/marshallers.go
+++ b/json/marshallers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"strings"
 
 	"slices"
 
@@ -74,9 +75,9 @@ func (m *Marshaller) Marshal(in any) error {
 	return nil
 }
 
-func (m *Marshaller) MarshalToString(in any) (string, error) {
+func (m *Marshaller) MarshalToString(in any, jsonEncoderOption ...json.Options) (string, error) {
 	buf := bytes.NewBuffer(nil)
-	if err := json.MarshalEncode(jsontext.NewEncoder(buf), in, json.WithMarshalers(m.marshallers)); err != nil {
+	if err := json.MarshalEncode(jsontext.NewEncoder(buf, jsonEncoderOption...), in, json.WithMarshalers(m.marshallers)); err != nil {
 		return "", err
 	}
 	return buf.String(), nil
@@ -196,4 +197,32 @@ func ToBase64(encoder *jsontext.Encoder, t []byte, options json.Options) error {
 
 func ToHex(encoder *jsontext.Encoder, t []byte, options json.Options) error {
 	return encoder.WriteToken(jsontext.String(hex.EncodeToString(t)))
+}
+
+func EncodeBase58(bytes []byte) string {
+	return base58.Encode(bytes)
+}
+
+func EncodeBase64(bytes []byte) string {
+	return base64.StdEncoding.EncodeToString(bytes)
+}
+
+func EncodeHex(bytes []byte) string {
+	return hex.EncodeToString(bytes)
+}
+
+// Encode encodes the given bytes using the specified encoding.
+func Encode(bytesEncoding string, bytes []byte) string {
+	switch {
+	case strings.EqualFold(bytesEncoding, "base58"):
+		return base58.Encode(bytes)
+
+	case strings.EqualFold(bytesEncoding, "base64"):
+		return base64.StdEncoding.EncodeToString(bytes)
+
+	case strings.EqualFold(bytesEncoding, "hex"):
+		return hex.EncodeToString(bytes)
+	}
+
+	panic(fmt.Errorf("unsupported bytes encoding: %s", bytesEncoding))
 }

--- a/proto/registry.go
+++ b/proto/registry.go
@@ -5,11 +5,15 @@ import (
 	"fmt"
 	"strings"
 
+	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/dynamicpb"
 	"google.golang.org/protobuf/types/known/anypb"
 )
+
+var _ protoregistry.MessageTypeResolver = (*Registry)(nil)
+var _ protoregistry.ExtensionTypeResolver = (*Registry)(nil)
 
 // Generate the flags based on Go code in this project directly, this however
 // creates a chicken & egg problem if there is compilation error within the project
@@ -129,4 +133,24 @@ func urlToMessageFullName(url string) protoreflect.FullName {
 	}
 
 	return message
+}
+
+// FindMessageByName implements protoregistry.MessageTypeResolver.
+func (r *Registry) FindMessageByName(message protoreflect.FullName) (protoreflect.MessageType, error) {
+	return r.Types.FindMessageByName(message)
+}
+
+// FindMessageByURL implements protoregistry.MessageTypeResolver.
+func (r *Registry) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+	return r.Types.FindMessageByURL(url)
+}
+
+// FindExtensionByName implements protoregistry.ExtensionTypeResolver.
+func (r *Registry) FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error) {
+	return r.Types.FindExtensionByName(field)
+}
+
+// FindExtensionByNumber implements protoregistry.ExtensionTypeResolver.
+func (r *Registry) FindExtensionByNumber(message protoreflect.FullName, field protowire.Number) (protoreflect.ExtensionType, error) {
+	return r.Types.FindExtensionByNumber(message, field)
 }


### PR DESCRIPTION
There is now a common flag for all `tools` subcommand `output` that can be one of: text, json, jsonl, protojson or protojsonl.

Commands that had flags defined have been removed, this should be backward compatible.

The text printer is now more clever and is able to print details about most blocks.