### PR TITLE
Add global request pool support for Substreams tier1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 ### Substreams
 
+* Integrated the `GlobalRequestPool` service in the `Tier1App` to manage global requests pooling.
+* 
+
+* Added new flag `substreams-tier1-global-request-pool-keep-alive-delay` delay between two keep alive call to the global worker pool for request. Default is 25s 
+* Added new flag `substreams-tier1-default-max-request-per-user` default max request per user, this will be use of the global worker pool is not reachable. Default is 5
+* Added new flag `substreams-tier1-default-minimal-request-life-time-second` default minimal request life time, this will be use of the global worker pool is not reachable. . Default is 180
+
 * Add shared cache for tier1 execution near HEAD, to prevent multiple tier1 instances from reprocessing the same module on the same block when it comes in (ex: foundational modules)
 * Improved fetching of state caches on tier1 requests to speed up "time to first data"
 

--- a/cmd/apps/substreams_tier1.go
+++ b/cmd/apps/substreams_tier1.go
@@ -32,6 +32,7 @@ import (
 	app "github.com/streamingfast/substreams/app"
 	"github.com/streamingfast/substreams/client"
 	"github.com/streamingfast/substreams/orchestrator/work"
+	"github.com/streamingfast/substreams/service"
 	"github.com/streamingfast/substreams/wasm"
 	pbworker "github.com/streamingfast/worker-pool-protocol/pb/sf/worker/v1"
 	"go.uber.org/zap"
@@ -74,6 +75,9 @@ func RegisterSubstreamsTier1App[B firecore.Block](chain *firecore.Chain[B], root
 			`))
 			cmd.Flags().String("substreams-tier1-global-worker-pool-address", "", "Address of the global worker pool to use for the substreams tier1. (disabled if empty)")
 			cmd.Flags().Duration("substreams-tier1-global-worker-pool-keep-alive-delay", 25*time.Second, "Delay between two keep alive call to the global worker pool. Default is 25s")
+			cmd.Flags().Duration("substreams-tier1-global-request-pool-keep-alive-delay", 25*time.Second, "Delay between two keep alive call to the global worker pool for request. Default is 25s")
+			cmd.Flags().Uint64("substreams-tier1-default-max-request-per-user", 3, "default max request per user, this will be use of the global worker pool is not reachable. Default is 5")
+			cmd.Flags().Uint64("substreams-tier1-default-minimal-request-life-time-second", 180, "default max request per user, this will be use of the global worker pool is not reachable. Default is 5")
 			// all substreams
 			registerCommonSubstreamsFlags(cmd)
 			return nil
@@ -133,8 +137,6 @@ func RegisterSubstreamsTier1App[B firecore.Block](chain *firecore.Chain[B], root
 			if err != nil {
 				return nil, fmt.Errorf("getting temporary directory: %w", err)
 			}
-			substreamsGlobalWorkerPoolAddress := viper.GetString("substreams-tier1-global-worker-pool-address")
-			substreamsGlobalWorkerPoolKeepAliveDelay := viper.GetDuration("substreams-tier1-global-worker-pool-keep-alive-delay")
 
 			config := app.NewDefaultTier1Config()
 			config.MeteringConfig = GetCommonMeteringPluginValue()
@@ -172,6 +174,9 @@ func RegisterSubstreamsTier1App[B firecore.Block](chain *firecore.Chain[B], root
 
 			clientFactory := client.NewInternalClientFactory(subRequestsClientConfig)
 			workerPoolFactory := work.NewSimpleWorkerPoolFactory(clientFactory).WorkerPool
+			var globalRequestPool *service.GlobalRequestPool
+
+			substreamsGlobalWorkerPoolAddress := viper.GetString("substreams-tier1-global-worker-pool-address")
 
 			if substreamsGlobalWorkerPoolAddress != "" {
 				grpcClientConnection, err := dgrpc.NewInternalNoWaitClientConn(substreamsGlobalWorkerPoolAddress)
@@ -182,8 +187,17 @@ func RegisterSubstreamsTier1App[B firecore.Block](chain *firecore.Chain[B], root
 				workerPoolFactory = work.NewGlobalWorkerPoolFactory(
 					workerPoolClient,
 					clientFactory,
-					substreamsGlobalWorkerPoolKeepAliveDelay,
+					viper.GetDuration("substreams-tier1-global-worker-pool-keep-alive-delay"),
 				).WorkerPool
+
+				defaultMinimalWorkerLifeDuration := time.Duration(viper.GetInt("substreams-tier1-default-minimal-request-life-time-second")) * time.Second
+				globalRequestPool = service.NewGlobalRequestPool(
+					workerPoolClient,
+					viper.GetDuration("substreams-tier1-global-request-pool-keep-alive-delay"),
+					viper.GetUint64("substreams-tier1-default-max-request-per-user"),
+					defaultMinimalWorkerLifeDuration,
+					appLogger,
+				)
 			}
 
 			return app.NewTier1(appLogger,
@@ -194,6 +208,7 @@ func RegisterSubstreamsTier1App[B firecore.Block](chain *firecore.Chain[B], root
 					CheckPendingShutDown:  runtime.IsPendingShutdown,
 					InfoServer:            runtime.InfoServer,
 					WorkerPoolFactory:     workerPoolFactory,
+					GlobalRequestPool:     globalRequestPool,
 				}), nil
 		},
 	})

--- a/cmd/apps/substreams_tier1.go
+++ b/cmd/apps/substreams_tier1.go
@@ -77,7 +77,7 @@ func RegisterSubstreamsTier1App[B firecore.Block](chain *firecore.Chain[B], root
 			cmd.Flags().Duration("substreams-tier1-global-worker-pool-keep-alive-delay", 25*time.Second, "Delay between two keep alive call to the global worker pool. Default is 25s")
 			cmd.Flags().Duration("substreams-tier1-global-request-pool-keep-alive-delay", 25*time.Second, "Delay between two keep alive call to the global worker pool for request. Default is 25s")
 			cmd.Flags().Uint64("substreams-tier1-default-max-request-per-user", 3, "default max request per user, this will be use of the global worker pool is not reachable. Default is 5")
-			cmd.Flags().Uint64("substreams-tier1-default-minimal-request-life-time-second", 180, "default max request per user, this will be use of the global worker pool is not reachable. Default is 5")
+			cmd.Flags().Uint64("substreams-tier1-default-minimal-request-life-time-second", 180, "default minimal request request life time, this will be use of the global worker pool is not reachable.")
 			// all substreams
 			registerCommonSubstreamsFlags(cmd)
 			return nil

--- a/cmd/apps/substreams_tier2.go
+++ b/cmd/apps/substreams_tier2.go
@@ -21,14 +21,12 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/streamingfast/dgrpc"
 	discoveryservice "github.com/streamingfast/dgrpc/server/discovery-service"
 	firecore "github.com/streamingfast/firehose-core"
 	"github.com/streamingfast/firehose-core/launcher"
 	"github.com/streamingfast/logging"
 	"github.com/streamingfast/substreams/app"
 	"github.com/streamingfast/substreams/wasm"
-	pbworker "github.com/streamingfast/worker-pool-protocol/pb/sf/worker/v1"
 	"go.uber.org/zap"
 )
 
@@ -46,7 +44,6 @@ func RegisterSubstreamsTier2App[B firecore.Block](chain *firecore.Chain[B], root
 			cmd.Flags().String("substreams-tier2-grpc-listen-addr", firecore.SubstreamsTier2GRPCServingAddr, "Address on which the substreams tier2 will listen. Default is plain-text, appending a '*' to the end to jkkkj")
 			cmd.Flags().String("substreams-tier2-discovery-service-url", "", "URL to advertise presence to the grpc discovery service") //traffic-director://xds?vpc_network=vpc-global&use_xds_reds=true
 			cmd.Flags().Uint64("substreams-tier2-max-concurrent-requests", 0, "Maximum number of concurrent requests allowed on the server. When the tier2 service hits this limit, it will set itself as 'Not Ready' until requests are processed. Default 0 (no limit)")
-			cmd.Flags().String("substreams-tier2-global-worker-pool-address", "", "Address of the global worker pool to use for the substreams tier1. (disabled if empty)")
 			// all substreams
 			registerCommonSubstreamsFlags(cmd)
 			return nil
@@ -58,7 +55,6 @@ func RegisterSubstreamsTier2App[B firecore.Block](chain *firecore.Chain[B], root
 
 			maximumConcurrentRequests := viper.GetUint64("substreams-tier2-max-concurrent-requests")
 			executionTimeout := viper.GetDuration("substreams-block-execution-timeout")
-			substreamsGlobalWorkerPoolAddress := viper.GetString("substreams-tier2-global-worker-pool-address")
 
 			tracing := os.Getenv("SUBSTREAMS_TRACING") == "modules_exec"
 
@@ -90,16 +86,6 @@ func RegisterSubstreamsTier2App[B firecore.Block](chain *firecore.Chain[B], root
 				return nil, fmt.Errorf("getting temporary directory: %w", err)
 			}
 
-			var remoteWorkerPoolClient pbworker.WorkerPoolClient
-			if substreamsGlobalWorkerPoolAddress != "" {
-				grpcClientConnection, err := dgrpc.NewInternalClientConn(substreamsGlobalWorkerPoolAddress)
-				if err != nil {
-					return nil, fmt.Errorf("unable to create grpc client connection to global worker pool: %w", err)
-				}
-				remoteWorkerPoolClient = pbworker.NewWorkerPoolClient(grpcClientConnection)
-
-			}
-
 			return app.NewTier2(appLogger,
 				&app.Tier2Config{
 					Tracing: tracing,
@@ -113,7 +99,6 @@ func RegisterSubstreamsTier2App[B firecore.Block](chain *firecore.Chain[B], root
 					MaximumConcurrentRequests: maximumConcurrentRequests,
 				}, &app.Tier2Modules{
 					CheckPendingShutDown: runtime.IsPendingShutdown,
-					RemoteWorkerClient:   remoteWorkerPoolClient,
 				}), nil
 		},
 	})

--- a/devel/substreams/substreams.yaml
+++ b/devel/substreams/substreams.yaml
@@ -15,7 +15,6 @@ start:
     substreams-tier1-subrequests-endpoint: :9001
 
     substreams-tier1-global-worker-pool-address: :9002
-    substreams-tier1-global-worker-pool-keep-alive-delay: 25s
+    substreams-tier1-global-worker-pool-keep-alive-delay: 1s
 
     substreams-tier2-grpc-listen-addr: :9001
-    substreams-tier2-global-worker-pool-address: :9002

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/streamingfast/firehose-core
 
 go 1.23.4
 
+replace github.com/streamingfast/substreams => ../substreams
+
 require (
 	buf.build/gen/go/bufbuild/reflect/connectrpc/go v1.16.1-20240117202343-bf8f65e8876c.1
 	buf.build/gen/go/bufbuild/reflect/protocolbuffers/go v1.33.0-20240117202343-bf8f65e8876c.1
@@ -32,7 +34,7 @@ require (
 	github.com/streamingfast/pbgo v0.0.6-0.20250114182320-0b43084f4000
 	github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0
 	github.com/streamingfast/substreams v1.12.5-0.20250218203417-20083994f5bd
-	github.com/streamingfast/worker-pool-protocol v0.0.0-20250211140743-fb8ffbc05fbc
+	github.com/streamingfast/worker-pool-protocol v0.0.0-20250218145136-4ad271e36e39
 	github.com/stretchr/testify v1.10.0
 	github.com/test-go/testify v1.1.4
 	go.uber.org/multierr v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/streamingfast/firehose-core
 
 go 1.23.4
 
-replace github.com/streamingfast/substreams => ../substreams
-
 require (
 	buf.build/gen/go/bufbuild/reflect/connectrpc/go v1.16.1-20240117202343-bf8f65e8876c.1
 	buf.build/gen/go/bufbuild/reflect/protocolbuffers/go v1.33.0-20240117202343-bf8f65e8876c.1
@@ -33,7 +31,7 @@ require (
 	github.com/streamingfast/payment-gateway v0.0.0-20240426151444-581e930c76e2
 	github.com/streamingfast/pbgo v0.0.6-0.20250114182320-0b43084f4000
 	github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0
-	github.com/streamingfast/substreams v1.12.5-0.20250218203417-20083994f5bd
+	github.com/streamingfast/substreams v1.12.5-0.20250220133652-c26beb0727dd
 	github.com/streamingfast/worker-pool-protocol v0.0.0-20250218145136-4ad271e36e39
 	github.com/stretchr/testify v1.10.0
 	github.com/test-go/testify v1.1.4

--- a/go.sum
+++ b/go.sum
@@ -2197,12 +2197,10 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.12.5-0.20250218203417-20083994f5bd h1:tSmzSG9RvUawqwI/VFtlCH9zVF0XEnwBJsCrLhzoGZY=
-github.com/streamingfast/substreams v1.12.5-0.20250218203417-20083994f5bd/go.mod h1:5yaYWVuYDNJAzLaqxAEEyri87UuQqt2rkvN+D/zBMzo=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
-github.com/streamingfast/worker-pool-protocol v0.0.0-20250211140743-fb8ffbc05fbc h1:WrgK+ECYQpYd5n+IG7rDR88lkaXw3wef1UKlEBvZ6Bs=
-github.com/streamingfast/worker-pool-protocol v0.0.0-20250211140743-fb8ffbc05fbc/go.mod h1:fq44dFx8K9S3/9QOoIVk0s+ptEscfpQmftLog/9WYU4=
+github.com/streamingfast/worker-pool-protocol v0.0.0-20250218145136-4ad271e36e39 h1:NBBLx99rrGz/hxwHjHi+QyN07DfqcDC4zzuBEsH0/vE=
+github.com/streamingfast/worker-pool-protocol v0.0.0-20250218145136-4ad271e36e39/go.mod h1:fq44dFx8K9S3/9QOoIVk0s+ptEscfpQmftLog/9WYU4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/go.sum
+++ b/go.sum
@@ -2197,6 +2197,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
+github.com/streamingfast/substreams v1.12.5-0.20250220133652-c26beb0727dd h1:kTW1pZYjtT8KvfSnJ9TK50QkkgRPQYJN8327Ep77OnQ=
+github.com/streamingfast/substreams v1.12.5-0.20250220133652-c26beb0727dd/go.mod h1:2/yOQAnNP4EQ66buwMF4eOVUgPN6RWrh8VxHT5LL5vc=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20250218145136-4ad271e36e39 h1:NBBLx99rrGz/hxwHjHi+QyN07DfqcDC4zzuBEsH0/vE=


### PR DESCRIPTION
### Configuration and Flag Additions:
* Added new flags for `substreams-tier1-global-request-pool-keep-alive-delay`, `substreams-tier1-default-max-request-per-user`, and `substreams-tier1-default-minimal-request-life-time-second` to the `RegisterSubstreamsTier1App` function.

### Service Integration:
* Integrated the `GlobalRequestPool` service in the `RegisterSubstreamsTier1App` function to manage global requests. 
