### PR TITLE
fix: prevent mutex lock leakage in bundler when MergeAndStore fails

### DIFF
--- a/merger/bundler.go
+++ b/merger/bundler.go
@@ -212,11 +212,17 @@ func (b *Bundler) ProcessBlock(_ *pbbstream.Block, obj interface{}) error {
 	b.irreversibleBlocks = []*bstream.OneBlockFile{lastBlock, obf}
 	b.baseBlockNum += b.bundleSize
 	for obf.Num > b.baseBlockNum+b.bundleSize { // skip more merged-block-files
-		b.inProcess.Lock()
-		if err := b.io.MergeAndStore(context.Background(), b.baseBlockNum, []*bstream.OneBlockFile{lastBlock}); err != nil { // lastBlock will be excluded from bundle but is useful to bundler
+		var err error
+		func() {
+			b.inProcess.Lock()
+			defer b.inProcess.Unlock()
+			err = b.io.MergeAndStore(context.Background(), b.baseBlockNum, []*bstream.OneBlockFile{lastBlock})
+		}()
+		
+		if err != nil {
 			return err
 		}
-		b.inProcess.Unlock()
+		
 		b.baseBlockNum += b.bundleSize
 	}
 	b.Unlock()


### PR DESCRIPTION
This commit fixes a deadlock issue in the merger bundler when processing blocks that are ahead of the current bundle boundary. The previous implementation would acquire a mutex lock before calling MergeAndStore(), but if this operation failed, the function would return early without releasing the lock, preventing other operations from proceeding.

The fix encapsulates the critical section in a closure with a deferred unlock, ensuring the mutex is always released regardless of error conditions. This prevents lock leakage and potential deadlocks during error scenarios.