### PR TITLE
Close pipe in MergedBlocksWriter.WriteBundle to avoid goroutine leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Operators, you should copy/paste content of this content straight to your projec
 
 If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you should copy the content between those 2 version to your own repository, replacing placeholder value `fire{chain}` with your chain's own binary.
 
+## Unreleased
+
+### Fixed
+
+* `MergedBlocksWriter.WriteBundle`: close the read end of the internal pipe and wait for the producer goroutine to finish before returning. Previously, if the underlying `Store.WriteObject` returned without consuming the reader (e.g. an S3 destination skipping an existing object when `overwrite` is disabled), the producer goroutine would block forever on its next pipe write, leaking the goroutine and pinning the bundle's blocks in memory. This affected `tools download-from-firehose` against S3 destinations that already contained any of the requested bundles.
+
 ## v1.14.2
 
 * Library `dsession` bumped to latest version which brings:

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/streamingfast/dmetering v0.0.0-20251027175535-4fd530934b97
 	github.com/streamingfast/dmetrics v0.0.0-20260109212625-35256f512c62
 	github.com/streamingfast/dsession v0.0.0-20260414190543-79b9846e7c58
-	github.com/streamingfast/dstore v0.2.3
+	github.com/streamingfast/dstore v0.2.4-0.20260427175250-c0d9ab9f857e
 	github.com/streamingfast/firehose-networks v0.2.2
 	github.com/streamingfast/logging v1.2.2
 	github.com/streamingfast/payment-gateway v0.0.0-20251124143836-60d98e3546f5

--- a/go.sum
+++ b/go.sum
@@ -2315,8 +2315,8 @@ github.com/streamingfast/dmetrics v0.0.0-20260109212625-35256f512c62 h1:Tb4T34Im
 github.com/streamingfast/dmetrics v0.0.0-20260109212625-35256f512c62/go.mod h1:JbxEDbzWRG1dHdNIPrYfuPllEkktZMgm40AwVIBENcw=
 github.com/streamingfast/dsession v0.0.0-20260414190543-79b9846e7c58 h1:at7VPRhGImEz71Tr7I6Wtql9KSxQhKBAPkCDyuEIO9g=
 github.com/streamingfast/dsession v0.0.0-20260414190543-79b9846e7c58/go.mod h1:ldDwFqr20xXyaLhwDm7XlMaf2vvoZNOrjgsMcFJGtrw=
-github.com/streamingfast/dstore v0.2.3 h1:WQerHsINf2yT6Qj3mSwuxgWoDuiPkuqUolH0eQtnok0=
-github.com/streamingfast/dstore v0.2.3/go.mod h1:O7Lsvvz0AnIJmW/CidKSBHbyW5xAK6AyD7L9kQ58Bbw=
+github.com/streamingfast/dstore v0.2.4-0.20260427175250-c0d9ab9f857e h1:icvTTsb/CkJI9GN0Hm30nzQ0trQvugWFD+UpX8zkjAA=
+github.com/streamingfast/dstore v0.2.4-0.20260427175250-c0d9ab9f857e/go.mod h1:O7Lsvvz0AnIJmW/CidKSBHbyW5xAK6AyD7L9kQ58Bbw=
 github.com/streamingfast/dtracing v0.0.0-20260303163312-862cb0fb60c9 h1:RaMv0J2e30vQpJiKdWOGB1HObWtJ4/w4vEUkUhTYE+c=
 github.com/streamingfast/dtracing v0.0.0-20260303163312-862cb0fb60c9/go.mod h1:huOJyjMYS6K8upTuxDxaNd+emD65RrXoVBvh8f1/7Ns=
 github.com/streamingfast/dummy-blockchain v1.7.3 h1:rPheajbwc+hwh4XVRMaroET/p/lvlI7WGfqETBkIL18=

--- a/merged_blocks_writer.go
+++ b/merged_blocks_writer.go
@@ -74,9 +74,11 @@ func (w *MergedBlocksWriter) WriteBundle() error {
 	}
 
 	pr, pw := io.Pipe()
+	done := make(chan struct{})
 
 	go func() {
 		var err error
+		defer close(done)
 		defer func() {
 			pw.CloseWithError(err)
 		}()
@@ -98,6 +100,14 @@ func (w *MergedBlocksWriter) WriteBundle() error {
 	if err != nil {
 		w.Logger.Error("writing to store", zap.Error(err))
 	}
+
+	// If the store returned without consuming the reader (e.g. an S3 store
+	// skipping an already-existing object), the goroutine above would block
+	// forever on its next write to the pipe, pinning the bundle's blocks in
+	// memory. Closing the read end unblocks it; we then wait for it to
+	// finish so the captured slice is released before we return.
+	pr.Close()
+	<-done
 
 	w.LowBlockNum += 100
 	w.blocks = nil


### PR DESCRIPTION
## Summary

`Store.WriteObject` may return without consuming the reader. The most common (and only known) case is the S3 store short-circuiting when the destination object already exists and `overwrite` is disabled. When that happens, the producer goroutine spawned by `WriteBundle` blocks forever on its next pipe write, leaking the goroutine and pinning the bundle's ~100 block payloads in memory.

This affects `tools download-from-firehose` whenever the destination S3 bucket already contains any of the requested bundles (e.g. resuming a long download): one leaked goroutine + 100 leaked blocks per pre-existing bundle.

This change closes the read end of the pipe and waits for the producer to finish before returning, so the captured slice is released even when the store didn't drain it.

A complementary fix in `dstore` itself (drain the reader on the skip path) is at streamingfast/dstore#32. Either fix on its own resolves the leak; both together make the contract robust on both sides.

## Test plan

- [ ] `go build ./... && go vet .` (passes locally)
- [ ] Manual repro: run `tools download-from-firehose` against an S3 destination that already contains the requested bundles; confirm goroutine count and heap stay flat as the tool iterates over existing files (`pprof goroutine` / `inuse_space`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)