### PR TITLE
merger: add optional validation of one-block files before merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 ## Unreleased
 
+### Added
+
+- `merger`: new `--merger-validate-one-block-files` flag (default `false`). When enabled, each one-block file is validated before being merged: the DBIN framing, the block envelope and the block payload (protobuf wire-format) must decode, otherwise the merge fails with an error naming the offending one-block file. Without it, a corrupted one-block file is silently propagated into the merged-blocks store, poisoning every downstream consumer of the bundle (index-builder, firehose, substreams, ...).
+
 ### Changed
 
 - Bumped `dstore`: S3 store now suppresses the SDK's checksum validation warnings (sets `DisableLogOutputChecksumValidationSkipped` to `true`) and updates the AWS S3 SDK to a newer version.

--- a/cmd/apps/merger.go
+++ b/cmd/apps/merger.go
@@ -26,6 +26,7 @@ func RegisterMergerApp(rootLog *zap.Logger) {
 			cmd.Flags().Duration("merger-time-between-store-pruning", time.Minute, "Delay between source store pruning loops")
 			cmd.Flags().Int("merger-delete-threads", 8, "Number of threads for deleting files in parallel (increase this in case the merger isn't able to keep up with deleting one-block files).")
 			cmd.Flags().Int("merger-max-merging-threads", 4, "Maximum number of bundles that can be merged in parallel. Increasing this allows the merger to catch up faster when behind, at the cost of more memory usage.")
+			cmd.Flags().Bool("merger-validate-one-block-files", false, "Validate that each one-block file contains a single well-formed block (DBIN framing, block envelope and protobuf wire-format of the payload) before merging it, failing the merge instead of propagating a corrupted block to the merged-blocks store. Adds some CPU and memory overhead.")
 			return nil
 		},
 		FactoryFunc: func(runtime *launcher.Runtime) (launcher.App, error) {
@@ -46,6 +47,7 @@ func RegisterMergerApp(rootLog *zap.Logger) {
 				TimeBetweenPolling:           viper.GetDuration("merger-time-between-store-lookups"),
 				FilesDeleteThreads:           viper.GetInt("merger-delete-threads"),
 				MaxMergingThreads:            viper.GetInt("merger-max-merging-threads"),
+				ValidateOneBlockFiles:        viper.GetBool("merger-validate-one-block-files"),
 				IsPendingShutdown:            runtime.IsPendingShutdown,
 			}), nil
 		},

--- a/merger/app/merger/app.go
+++ b/merger/app/merger/app.go
@@ -36,8 +36,9 @@ type Config struct {
 	StorageMergedBlocksFilesPath string
 	StorageForkedBlocksFilesPath string
 
-	FilesDeleteThreads int
-	MaxMergingThreads  int
+	FilesDeleteThreads    int
+	MaxMergingThreads     int
+	ValidateOneBlockFiles bool
 
 	GRPCListenAddr        string
 	HTTPHealthzListenAddr string
@@ -98,7 +99,8 @@ func (a *App) Run() error {
 		5,
 		500*time.Millisecond,
 		bundleSize,
-		a.config.FilesDeleteThreads)
+		a.config.FilesDeleteThreads,
+		a.config.ValidateOneBlockFiles)
 
 	m := merger.NewMerger(
 		zlog,

--- a/merger/bundlereader.go
+++ b/merger/bundlereader.go
@@ -15,18 +15,26 @@
 package merger
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
 	"github.com/streamingfast/bstream"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 // NewStreamingBundleReader creates an io.Reader that streams one-block-files directly from storage
 // without loading them into memory. It opens each file via opener one at a time, strips DBIN headers
 // from all files except the first, and pipes the concatenated output to the returned reader.
-func NewStreamingBundleReader(ctx context.Context, logger *zap.Logger, oneBlockFiles []*bstream.OneBlockFile, anyOneBlockFile *bstream.OneBlockFile, opener func(context.Context, *bstream.OneBlockFile) (io.ReadCloser, error)) (io.Reader, error) {
+//
+// When validate is true, each one-block file is instead buffered (one file at a time, so memory
+// stays bounded to a single block) and checked with validateOneBlockFile before being written out,
+// so that corrupted blocks are rejected instead of being propagated to the merged-blocks store.
+func NewStreamingBundleReader(ctx context.Context, logger *zap.Logger, oneBlockFiles []*bstream.OneBlockFile, anyOneBlockFile *bstream.OneBlockFile, opener func(context.Context, *bstream.OneBlockFile) (io.ReadCloser, error), validate bool) (io.Reader, error) {
 	// Open anyOneBlockFile just to determine the DBIN header length
 	headerReader, err := opener(ctx, anyOneBlockFile)
 	if err != nil {
@@ -64,6 +72,32 @@ func NewStreamingBundleReader(ctx context.Context, logger *zap.Logger, oneBlockF
 				return
 			}
 
+			if validate {
+				data, err := io.ReadAll(r)
+				r.Close()
+				if err != nil {
+					pw.CloseWithError(fmt.Errorf("reading one_block_file %s: %w", obf.CanonicalName, err))
+					return
+				}
+
+				if len(data) < headerLen {
+					pw.CloseWithError(fmt.Errorf("one_block_file %s is too short (%d bytes) to contain a DBIN header", obf.CanonicalName, len(data)))
+					return
+				}
+
+				if err := validateOneBlockFile(data); err != nil {
+					pw.CloseWithError(fmt.Errorf("refusing to merge corrupted one_block_file %s: %w", obf.CanonicalName, err))
+					return
+				}
+
+				// Skip the DBIN header on each individual file
+				if _, err := pw.Write(data[headerLen:]); err != nil {
+					pw.CloseWithError(err)
+					return
+				}
+				continue
+			}
+
 			// Skip the DBIN header on each individual file
 			if _, err := io.CopyN(io.Discard, r, int64(headerLen)); err != nil {
 				r.Close()
@@ -82,4 +116,41 @@ func NewStreamingBundleReader(ctx context.Context, logger *zap.Logger, oneBlockF
 	}()
 
 	return pr, nil
+}
+
+// validateOneBlockFile ensures the file contains exactly one well-formed block: the DBIN
+// framing and the pbbstream.Block envelope must decode, and the block payload must be valid
+// protobuf wire-format. Corrupted blocks are caught here instead of being propagated to the
+// merged-blocks store, where they would poison every downstream consumer of the bundle
+// (index-builder, firehose, substreams, ...).
+func validateOneBlockFile(data []byte) error {
+	blkReader, err := bstream.NewDBinBlockReader(bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("reading DBIN header: %w", err)
+	}
+
+	blk, err := blkReader.Read()
+	if err != nil && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("decoding block: %w", err)
+	}
+	if blk == nil {
+		return fmt.Errorf("file contains no block")
+	}
+
+	if len(blk.Payload.GetValue()) == 0 {
+		return fmt.Errorf("block #%d (%s) has an empty payload", blk.Number, blk.Id)
+	}
+
+	// Unmarshalling into an empty message walks the whole payload wire-format without
+	// requiring knowledge of the chain-specific block type, catching corruption that would
+	// otherwise surface as 'proto: cannot parse invalid wire-format data' in consumers.
+	if err := (proto.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(blk.Payload.Value, &emptypb.Empty{}); err != nil {
+		return fmt.Errorf("block #%d (%s) payload (%s) is corrupted: %w", blk.Number, blk.Id, blk.Payload.TypeUrl, err)
+	}
+
+	if _, err := blkReader.Read(); !errors.Is(err, io.EOF) {
+		return fmt.Errorf("block #%d (%s): expected exactly one block in file, found trailing data", blk.Number, blk.Id)
+	}
+
+	return nil
 }

--- a/merger/bundlereader_test.go
+++ b/merger/bundlereader_test.go
@@ -11,7 +11,10 @@ import (
 	"time"
 
 	"github.com/streamingfast/bstream"
+	pbbstream "github.com/streamingfast/bstream/pb/sf/bstream/v1"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func inMemoryOpener(_ context.Context, obf *bstream.OneBlockFile) (io.ReadCloser, error) {
@@ -19,33 +22,40 @@ func inMemoryOpener(_ context.Context, obf *bstream.OneBlockFile) (io.ReadCloser
 }
 
 func TestStreamingBundleReader_ReadSimpleFiles(t *testing.T) {
-	bundle := NewTestBundle()
+	for _, validate := range []bool{false, true} {
+		t.Run(fmt.Sprintf("validate_%t", validate), func(t *testing.T) {
+			bundle := NewTestBundle(t)
 
-	r, err := NewStreamingBundleReader(context.Background(), testLogger, bundle, bundle[0], inMemoryOpener)
-	require.NoError(t, err)
+			r, err := NewStreamingBundleReader(context.Background(), testLogger, bundle, bundle[0], inMemoryOpener, validate)
+			require.NoError(t, err)
 
-	all, err := ioutil.ReadAll(r)
-	require.NoError(t, err)
+			all, err := ioutil.ReadAll(r)
+			require.NoError(t, err)
 
-	// Expected: DBIN header once, then each block's payload (without their individual headers)
-	expected := append(testOneBlockHeader, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6)
-	require.Equal(t, expected, all)
+			// Expected: DBIN header once, then each block's bytes (without their individual headers)
+			headerLen := testDBinHeaderLen(t, bundle[0].MemoizeData)
+			expected := append([]byte{}, bundle[0].MemoizeData...)
+			expected = append(expected, bundle[1].MemoizeData[headerLen:]...)
+			expected = append(expected, bundle[2].MemoizeData[headerLen:]...)
+			require.Equal(t, expected, all)
+		})
+	}
 }
 
 func TestStreamingBundleReader_OpenerErrorOnHeader(t *testing.T) {
-	bundle := NewTestBundle()
+	bundle := NewTestBundle(t)
 
 	opener := func(_ context.Context, obf *bstream.OneBlockFile) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("storage unavailable")
 	}
 
-	_, err := NewStreamingBundleReader(context.Background(), testLogger, bundle, bundle[0], opener)
+	_, err := NewStreamingBundleReader(context.Background(), testLogger, bundle, bundle[0], opener, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "storage unavailable")
 }
 
 func TestStreamingBundleReader_OpenerErrorOnBlock(t *testing.T) {
-	bundle := NewTestBundle()
+	bundle := NewTestBundle(t)
 	callCount := 0
 
 	opener := func(_ context.Context, obf *bstream.OneBlockFile) (io.ReadCloser, error) {
@@ -57,7 +67,7 @@ func TestStreamingBundleReader_OpenerErrorOnBlock(t *testing.T) {
 		return nil, fmt.Errorf("block download failed")
 	}
 
-	r, err := NewStreamingBundleReader(context.Background(), testLogger, bundle, bundle[0], opener)
+	r, err := NewStreamingBundleReader(context.Background(), testLogger, bundle, bundle[0], opener, false)
 	require.NoError(t, err)
 
 	_, err = ioutil.ReadAll(r)
@@ -66,11 +76,11 @@ func TestStreamingBundleReader_OpenerErrorOnBlock(t *testing.T) {
 }
 
 func TestStreamingBundleReader_ContextCancellation(t *testing.T) {
-	bundle := NewTestBundle()
+	bundle := NewTestBundle(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	r, err := NewStreamingBundleReader(ctx, testLogger, bundle, bundle[0], inMemoryOpener)
+	r, err := NewStreamingBundleReader(ctx, testLogger, bundle, bundle[0], inMemoryOpener, false)
 	require.NoError(t, err)
 
 	_, err = ioutil.ReadAll(r)
@@ -78,18 +88,97 @@ func TestStreamingBundleReader_ContextCancellation(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
-func TestStreamingBundleReader_RealBlockFiles(t *testing.T) {
-	bundle := []*bstream.OneBlockFile{
-		NewTestOneBlockFileFromFile(t, "0000000001-20150730T152628.0-13406cb6-b1cb8fa3.dbin"),
-		NewTestOneBlockFileFromFile(t, "0000000002-20150730T152657.0-044698c9-13406cb6.dbin"),
-		NewTestOneBlockFileFromFile(t, "0000000003-20150730T152728.0-a88cf741-044698c9.dbin"),
-	}
+func TestStreamingBundleReader_CorruptPayload(t *testing.T) {
+	bundle := NewTestBundle(t)
 
-	r, err := NewStreamingBundleReader(context.Background(), testLogger, bundle, bundle[0], inMemoryOpener)
+	// 0xff starts a field with wire type 7, which does not exist: this payload is
+	// invalid protobuf wire-format while the block envelope around it stays valid,
+	// mirroring a corrupted block produced by a faulty reader node
+	bundle[1] = newTestOneBlockFile(t, "o2", 2, []byte{0xff, 0xff, 0xff})
+
+	r, err := NewStreamingBundleReader(context.Background(), testLogger, bundle, bundle[0], inMemoryOpener, true)
 	require.NoError(t, err)
-	data, err := ioutil.ReadAll(r)
+
+	_, err = ioutil.ReadAll(r)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "refusing to merge corrupted one_block_file o2")
+	require.Contains(t, err.Error(), "block #2")
+	require.Contains(t, err.Error(), "invalid wire-format")
+}
+
+func TestStreamingBundleReader_CorruptPayloadPassesWithoutValidation(t *testing.T) {
+	// documents the default behavior: without validation, the merger streams
+	// one-block files as-is, corrupted or not
+	bundle := NewTestBundle(t)
+	bundle[1] = newTestOneBlockFile(t, "o2", 2, []byte{0xff, 0xff, 0xff})
+
+	r, err := NewStreamingBundleReader(context.Background(), testLogger, bundle, bundle[0], inMemoryOpener, false)
 	require.NoError(t, err)
-	require.NotEmpty(t, data)
+
+	_, err = ioutil.ReadAll(r)
+	require.NoError(t, err)
+}
+
+func TestStreamingBundleReader_EmptyPayload(t *testing.T) {
+	bundle := NewTestBundle(t)
+	bundle[2] = newTestOneBlockFile(t, "o3", 3, nil)
+
+	r, err := NewStreamingBundleReader(context.Background(), testLogger, bundle, bundle[0], inMemoryOpener, true)
+	require.NoError(t, err)
+
+	_, err = ioutil.ReadAll(r)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "refusing to merge corrupted one_block_file o3")
+	require.Contains(t, err.Error(), "empty payload")
+}
+
+func TestStreamingBundleReader_TruncatedFile(t *testing.T) {
+	bundle := NewTestBundle(t)
+
+	truncated := newTestOneBlockFile(t, "o2", 2, []byte{0x08, 0x02})
+	truncated.MemoizeData = truncated.MemoizeData[:len(truncated.MemoizeData)-3]
+	bundle[1] = truncated
+
+	r, err := NewStreamingBundleReader(context.Background(), testLogger, bundle, bundle[0], inMemoryOpener, true)
+	require.NoError(t, err)
+
+	_, err = ioutil.ReadAll(r)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "refusing to merge corrupted one_block_file o2")
+}
+
+func TestStreamingBundleReader_RealBlockFiles(t *testing.T) {
+	for _, validate := range []bool{false, true} {
+		t.Run(fmt.Sprintf("validate_%t", validate), func(t *testing.T) {
+			bundle := []*bstream.OneBlockFile{
+				NewTestOneBlockFileFromFile(t, "0000000001-20150730T152628.0-13406cb6-b1cb8fa3.dbin"),
+				NewTestOneBlockFileFromFile(t, "0000000002-20150730T152657.0-044698c9-13406cb6.dbin"),
+				NewTestOneBlockFileFromFile(t, "0000000003-20150730T152728.0-a88cf741-044698c9.dbin"),
+			}
+
+			r, err := NewStreamingBundleReader(context.Background(), testLogger, bundle, bundle[0], inMemoryOpener, validate)
+			require.NoError(t, err)
+			data, err := ioutil.ReadAll(r)
+			require.NoError(t, err)
+			require.NotEmpty(t, data)
+		})
+	}
+}
+
+func TestValidateOneBlockFile(t *testing.T) {
+	valid := newTestOneBlockFile(t, "o1", 1, []byte{0x08, 0x01})
+	require.NoError(t, validateOneBlockFile(valid.MemoizeData))
+
+	corrupted := newTestOneBlockFile(t, "o1", 1, []byte{0xff, 0xff, 0xff})
+	err := validateOneBlockFile(corrupted.MemoizeData)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "payload")
+
+	garbage := append([]byte{}, valid.MemoizeData...)
+	garbage = append(garbage, 0x42)
+	err = validateOneBlockFile(garbage)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "trailing data")
 }
 
 func NewTestOneBlockFileFromFile(t *testing.T, fileName string) *bstream.OneBlockFile {
@@ -107,20 +196,52 @@ func NewTestOneBlockFileFromFile(t *testing.T, fileName string) *bstream.OneBloc
 	}
 }
 
-var testOneBlockHeader = []byte("dbin\x00tes\x00\x00")
+// newTestOneBlockFile builds a valid one-block-file: a DBIN-framed pbbstream.Block whose
+// payload contains the given protobuf wire-format bytes
+func newTestOneBlockFile(t *testing.T, name string, num uint64, payload []byte) *bstream.OneBlockFile {
+	t.Helper()
 
-func NewTestBundle() []*bstream.OneBlockFile {
-	o1 := &bstream.OneBlockFile{
-		CanonicalName: "o1",
-		MemoizeData:   append(testOneBlockHeader, []byte{0x1, 0x2}...),
+	parentNum := uint64(0)
+	if num > 0 {
+		parentNum = num - 1
 	}
-	o2 := &bstream.OneBlockFile{
-		CanonicalName: "o2",
-		MemoizeData:   append(testOneBlockHeader, []byte{0x3, 0x4}...),
+
+	buf := bytes.NewBuffer(nil)
+	writer, err := bstream.NewDBinBlockWriter(buf)
+	require.NoError(t, err)
+	require.NoError(t, writer.Write(&pbbstream.Block{
+		Id:        fmt.Sprintf("%08x", num),
+		Number:    num,
+		ParentId:  fmt.Sprintf("%08x", parentNum),
+		ParentNum: parentNum,
+		LibNum:    parentNum,
+		Timestamp: timestamppb.New(time.Date(2015, 7, 30, 15, 26, 28, 0, time.UTC)),
+		Payload: &anypb.Any{
+			TypeUrl: "type.googleapis.com/sf.test.type.v1.Block",
+			Value:   payload,
+		},
+	}))
+
+	return &bstream.OneBlockFile{
+		CanonicalName: name,
+		Filenames:     map[string]bool{name: true},
+		Num:           num,
+		MemoizeData:   buf.Bytes(),
 	}
-	o3 := &bstream.OneBlockFile{
-		CanonicalName: "o3",
-		MemoizeData:   append(testOneBlockHeader, []byte{0x5, 0x6}...),
+}
+
+func testDBinHeaderLen(t *testing.T, data []byte) int {
+	t.Helper()
+	reader, err := bstream.NewDBinBlockReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	return len(reader.Header.RawBytes)
+}
+
+func NewTestBundle(t *testing.T) []*bstream.OneBlockFile {
+	t.Helper()
+	return []*bstream.OneBlockFile{
+		newTestOneBlockFile(t, "o1", 1, []byte{0x08, 0x01}),
+		newTestOneBlockFile(t, "o2", 2, []byte{0x08, 0x02}),
+		newTestOneBlockFile(t, "o3", 3, []byte{0x08, 0x03}),
 	}
-	return []*bstream.OneBlockFile{o1, o2, o3}
 }

--- a/merger/merger_io.go
+++ b/merger/merger_io.go
@@ -62,7 +62,8 @@ type DStoreIO struct {
 	retryAttempts int
 	retryCooldown time.Duration
 
-	bundleSize uint64
+	bundleSize         uint64
+	validateBlockFiles bool
 
 	logger *zap.Logger
 	od     *oneBlockFilesDeleter
@@ -78,18 +79,20 @@ func NewDStoreIO(
 	retryCooldown time.Duration,
 	bundleSize uint64,
 	numDeleteThreads int,
+	validateBlockFiles bool,
 ) IOInterface {
 
 	od := &oneBlockFilesDeleter{store: oneBlocksStore, logger: logger}
 	od.Start(numDeleteThreads, DefaultFilesDeleteBatchSize*2)
 	dstoreIO := &DStoreIO{
-		oneBlocksStore:    oneBlocksStore,
-		mergedBlocksStore: mergedBlocksStore,
-		retryAttempts:     retryAttempts,
-		retryCooldown:     retryCooldown,
-		bundleSize:        bundleSize,
-		logger:            logger,
-		od:                od,
+		oneBlocksStore:     oneBlocksStore,
+		mergedBlocksStore:  mergedBlocksStore,
+		retryAttempts:      retryAttempts,
+		retryCooldown:      retryCooldown,
+		bundleSize:         bundleSize,
+		validateBlockFiles: validateBlockFiles,
+		logger:             logger,
+		od:                 od,
 	}
 
 	forkAware := forkedBlocksStore != nil
@@ -139,7 +142,7 @@ func (s *DStoreIO) MergeAndStore(ctx context.Context, inclusiveLowerBlock uint64
 	err = Retry(s.logger, s.retryAttempts, s.retryCooldown, func() error {
 		inCtx, cancel := context.WithTimeout(ctx, WriteObjectTimeout)
 		defer cancel()
-		streamReader, err := NewStreamingBundleReader(ctx, s.logger, filteredOBF, anyOneBlockFile, s.OpenOneBlockFile)
+		streamReader, err := NewStreamingBundleReader(ctx, s.logger, filteredOBF, anyOneBlockFile, s.OpenOneBlockFile, s.validateBlockFiles)
 		if err != nil {
 			return err
 		}

--- a/merger/merger_io_test.go
+++ b/merger/merger_io_test.go
@@ -42,6 +42,7 @@ func TestNewDstore(t *testing.T) {
 		0,
 		100,
 		0,
+		false,
 	)
 
 	_, ok := store.(ForkAwareIOInterface)
@@ -57,6 +58,7 @@ func TestNewDstore(t *testing.T) {
 		0,
 		100,
 		0,
+		false,
 	)
 
 	_, ok = store.(ForkAwareIOInterface)
@@ -67,7 +69,7 @@ func newTestDStoreIO(
 	oneBlocksStore dstore.Store,
 	mergedBlocksStore dstore.Store,
 ) IOInterface {
-	return NewDStoreIO(testLogger, oneBlocksStore, mergedBlocksStore, nil, 0, 0, 100, 0)
+	return NewDStoreIO(testLogger, oneBlocksStore, mergedBlocksStore, nil, 0, 0, 100, 0, false)
 }
 
 func makeBlockReader(t *testing.T) io.ReadCloser {
@@ -170,8 +172,8 @@ func TestMergerIO_MergeUploadFilteredToZero(t *testing.T) {
 	b101 := block103Final101()
 	files := []*bstream.OneBlockFile{b100, b101}
 
-	b100.MemoizeData = append(testOneBlockHeader, []byte{0x0, 0x1, 0x2, 0x3}...)
-	b101.MemoizeData = append(testOneBlockHeader, []byte{0x0, 0x1, 0x2, 0x3}...)
+	b100.MemoizeData = newTestOneBlockFile(t, "b100", 100, []byte{0x08, 0x01}).MemoizeData
+	b101.MemoizeData = newTestOneBlockFile(t, "b101", 101, []byte{0x08, 0x01}).MemoizeData
 
 	oneBlockStore := dstore.NewMockStore(nil)
 	oneBlockStore.OpenObjectFunc = func(_ context.Context, name string) (io.ReadCloser, error) {
@@ -188,4 +190,29 @@ func TestMergerIO_MergeUploadFilteredToZero(t *testing.T) {
 	mio := newTestDStoreIO(oneBlockStore, dstore.NewMockStore(nil))
 	err := mio.MergeAndStore(context.Background(), 114, files)
 	require.NoError(t, err)
+}
+
+func TestMergerIO_MergeUploadCorruptBlockWithValidation(t *testing.T) {
+	files := []*bstream.OneBlockFile{
+		block100(),
+		block101(),
+	}
+
+	corrupted := newTestOneBlockFile(t, "corrupted", 100, []byte{0xff, 0xff, 0xff})
+
+	oneBlockStore := dstore.NewMockStore(nil)
+	oneBlockStore.OpenObjectFunc = func(_ context.Context, name string) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(corrupted.MemoizeData)), nil
+	}
+	mergedBlocksStore := dstore.NewMockStore(func(base string, f io.Reader) error {
+		_, err := io.ReadAll(f)
+		return err
+	})
+
+	mio := NewDStoreIO(testLogger, oneBlockStore, mergedBlocksStore, nil, 0, 0, 100, 0, true)
+
+	err := mio.MergeAndStore(context.Background(), 100, files)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "refusing to merge corrupted one_block_file")
+	require.Contains(t, err.Error(), "invalid wire-format")
 }


### PR DESCRIPTION
## Problem

The merger's streaming bundle reader byte-concatenates one-block files into the merged bundle without any decoding. A one-block file containing a corrupted block payload (e.g. produced by a faulty reader node) is silently propagated into the merged-blocks store, where it later poisons every consumer of the bundle — index-builder, firehose, substreams — typically surfacing much later as a bare `proto: cannot parse invalid wire-format data` (see #149).

We hit this in production on a MegaETH deployment: a single block with an invalid payload inside an otherwise-healthy 100-block bundle (valid zstd, valid DBIN framing, valid block envelope — only the inner payload was garbage).

## Change

New `--merger-validate-one-block-files` flag, **default `false`** — the existing pure-streaming behavior is preserved unless explicitly opted in.

When enabled, each one-block file is buffered (one file at a time, so memory stays bounded to a single block) and validated before being written into the bundle:

- DBIN framing and `pbbstream.Block` envelope must decode
- payload must be non-empty and valid protobuf wire-format — checked generically by unmarshalling into `emptypb.Empty` with `DiscardUnknown`, so no knowledge of the chain-specific block type is needed
- the file must contain exactly one block (no trailing data)

A corrupted file fails the merge with an error naming the file and block:

```
refusing to merge corrupted one_block_file 0006258830-...: block #6258830 (d82cd8…) payload (type.googleapis.com/sf.ethereum.type.v2.Block) is corrupted: proto: cannot parse invalid wire-format data
```

so the operator can re-extract the block instead of discovering the corruption much later in a downstream consumer.

## Testing

- New unit tests for `validateOneBlockFile` (corrupt payload, empty payload, truncated file, trailing data)
- Streaming output is byte-identical with validation on and off (`TestStreamingBundleReader_ReadSimpleFiles` runs both modes)
- Default pass-through behavior documented by `TestStreamingBundleReader_CorruptPayloadPassesWithoutValidation`
- End-to-end `MergeAndStore` failure path covered by `TestMergerIO_MergeUploadCorruptBlockWithValidation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)