### PR TITLE
Add reader block-size prometheus metrics

### DIFF
--- a/cmd/apps/reader_node.go
+++ b/cmd/apps/reader_node.go
@@ -171,6 +171,7 @@ func RegisterReaderNodeApp[B firecore.Block](chain *firecore.Chain[B], rootLog *
 			)
 
 			lineBufferSize := viper.GetUint64("reader-node-line-buffer-size")
+			metrics.LineBufferSize.SetUint64(lineBufferSize)
 
 			superviser := sv.SupervisorFactory(chain.ExecutableName, nodePath, nodeArguments, lineBufferSize, appLogger)
 			superviser.RegisterLogPlugin(sv.NewNodeLogPlugin(debugFirehose))

--- a/node-manager/app/node_reader_stdin/app.go
+++ b/node-manager/app/node_reader_stdin/app.go
@@ -27,6 +27,7 @@ import (
 	dgrpcfactory "github.com/streamingfast/dgrpc/server/factory"
 	nodeManager "github.com/streamingfast/firehose-core/node-manager"
 	logplugin "github.com/streamingfast/firehose-core/node-manager/log_plugin"
+	"github.com/streamingfast/firehose-core/node-manager/metrics"
 	"github.com/streamingfast/firehose-core/node-manager/mindreader"
 	"github.com/streamingfast/logging"
 	pbheadinfo "github.com/streamingfast/pbgo/sf/headinfo/v1"
@@ -165,6 +166,7 @@ func (a *App) Run() error {
 	if maxLineLength == 0 {
 		maxLineLength = 50 * 1024 * 1024
 	}
+	metrics.LineBufferSize.SetUint64(uint64(maxLineLength))
 
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Buffer(make([]byte, int(maxLineLength)), int(maxLineLength))

--- a/node-manager/metrics/common.go
+++ b/node-manager/metrics/common.go
@@ -20,6 +20,15 @@ import (
 
 var Metricset = dmetrics.NewSet()
 
+// MaxReadBlockSize tracks the largest single line (block) in bytes read out of the node
+// process so far. Compare it against LineBufferSize to know how close we are to the hard
+// 'reader-node-line-buffer-size' limit.
+var MaxReadBlockSize = Metricset.NewGauge("reader_node_max_read_block_size_bytes", "Largest single line (block) in bytes read out of the node process so far")
+
+// LineBufferSize reports the configured 'reader-node-line-buffer-size', the hard limit in
+// bytes that a single line (block) read out of the node process is allowed to reach.
+var LineBufferSize = Metricset.NewGauge("reader_node_line_buffer_size_bytes", "Configured hard limit in bytes for a single line (block) read out of the node process ('reader-node-line-buffer-size')")
+
 func NewHeadBlockTimeDrift(serviceName string) *dmetrics.HeadTimeDrift {
 	return Metricset.NewHeadTimeDrift(serviceName)
 }

--- a/node-manager/mindreader/mindreader.go
+++ b/node-manager/mindreader/mindreader.go
@@ -31,6 +31,7 @@ import (
 	"github.com/streamingfast/dstore"
 	"github.com/streamingfast/firehose-core/internal/utils"
 	nodeManager "github.com/streamingfast/firehose-core/node-manager"
+	"github.com/streamingfast/firehose-core/node-manager/metrics"
 	"github.com/streamingfast/logging"
 	"github.com/streamingfast/shutter"
 	"go.uber.org/zap"
@@ -495,6 +496,10 @@ func (p *MindReaderPlugin) readOneMessage(blocks chan<- *pbbstream.Block) error 
 func (p *MindReaderPlugin) LogLine(in string) {
 	if p.IsTerminating() {
 		return
+	}
+
+	if size := float64(len(in)); size > metrics.MaxReadBlockSize.Get() {
+		metrics.MaxReadBlockSize.SetFloat64(size)
 	}
 
 	p.lines <- in


### PR DESCRIPTION
Adds two prometheus gauges to know how close blocks read out of the node are to the hard `reader-node-line-buffer-size` limit:

- `reader_node_max_read_block_size_bytes` — high-water mark of the largest line (block) read out of the node, updated in `MindReaderPlugin.LogLine` (covers both managed-node and stdin readers).
- `reader_node_line_buffer_size_bytes` — fixed value of the configured `reader-node-line-buffer-size`, set in the managed-node reader and the stdin reader.

Watch the ratio of the two to alert before blocks hit the limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)