### PR TITLE
rpc: don't hold clients lock across the fetch call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 - Substreams: fix `Sinker.requestActiveStartBlock` not being set when the handler implements `SinkerSessionInitHandler`, which previously caused `ProgressMessageLastContiguousBlock` to be incorrect for production-mode mapper stages.
 - Substreams: detect reorgs in executed partial blocks even when the transaction hashes are identical. Previously a recomputed block whose only difference was its state (same, equally-ordered transactions) was not detected as replaced, so no reorg was triggered; more block fields are now validated to catch this.
 - Logging: `processing block` (and other bstream forkable hub/forkable lines) are now logged under the owning component's logger (`relayer`, `firehose`, `merger`, ...) instead of all appearing under the generic `bstream` logger, making it possible to tell which component emitted each line. Requires bstream `hub.WithLogger`.
+- `rpc`: `WithClientsContext` no longer holds the clients lock for the duration of the fetch callback, only while selecting a client. Holding it across the call serialized all concurrent callers, which made the block poller's parallel prefetching (`blockFetchBatchSize > 1`) run sequentially. The poller's in-flight fetch flag is now an `atomic.Bool`, fixing a data race on the parallel-fetch path.
 
 ### Security
 

--- a/blockpoller/poller.go
+++ b/blockpoller/poller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/streamingfast/bstream"
@@ -49,7 +50,7 @@ type BlockPoller[C any] struct {
 
 	optimisticallyPolledBlocks map[uint64]*BlockItem
 
-	fetching                       bool
+	fetching                       atomic.Bool
 	optimisticallyPolledBlocksLock sync.Mutex
 }
 
@@ -333,7 +334,7 @@ func (p *BlockPoller[C]) loadNextBlocks(requestedBlock uint64, numberOfBlockToFe
 
 	<-done
 
-	p.fetching = false
+	p.fetching.Store(false)
 
 	if nailer.Err() != nil {
 		return fmt.Errorf("failed optimistically fetch blocks starting at %d: %w", requestedBlock, nailer.Err())
@@ -355,12 +356,13 @@ func (p *BlockPoller[C]) requestBlock(blockNumber uint64, numberOfBlockToFetch i
 		blockItem, found := p.optimisticallyPolledBlocks[blockNumber]
 		p.optimisticallyPolledBlocksLock.Unlock()
 		if !found {
-			if !p.fetching {
+			// CompareAndSwap ensures exactly one fetch goroutine is in flight at a
+			// time, and makes the flag safe to read/write across goroutines.
+			if p.fetching.CompareAndSwap(false, true) {
 				go func() {
 					p.optimisticallyPolledBlocksLock.Lock()
 					p.optimisticallyPolledBlocks = map[uint64]*BlockItem{}
 					p.optimisticallyPolledBlocksLock.Unlock()
-					p.fetching = true
 					err := p.loadNextBlocks(blockNumber, numberOfBlockToFetch)
 					if err != nil {
 						p.Shutdown(err)

--- a/blockpoller/poller.go
+++ b/blockpoller/poller.go
@@ -356,8 +356,6 @@ func (p *BlockPoller[C]) requestBlock(blockNumber uint64, numberOfBlockToFetch i
 		blockItem, found := p.optimisticallyPolledBlocks[blockNumber]
 		p.optimisticallyPolledBlocksLock.Unlock()
 		if !found {
-			// CompareAndSwap ensures exactly one fetch goroutine is in flight at a
-			// time, and makes the flag safe to read/write across goroutines.
 			if p.fetching.CompareAndSwap(false, true) {
 				go func() {
 					p.optimisticallyPolledBlocksLock.Lock()

--- a/blockpoller/poller_parallel_test.go
+++ b/blockpoller/poller_parallel_test.go
@@ -1,0 +1,64 @@
+package blockpoller
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	pbbstream "github.com/streamingfast/bstream/pb/sf/bstream/v1"
+	"github.com/streamingfast/firehose-core/rpc"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// linChainFetcher is a thread-safe fetcher for a simple linear chain. It is used
+// to exercise parallel block fetching (blockFetchBatchSize > 1). It deliberately
+// delays LOWER block numbers MORE than higher ones, so the concurrent fetches
+// complete out of order — the poller must still fire blocks to the handler in
+// strict ascending order.
+type linChainFetcher struct {
+	libNum   uint64
+	maxBlock uint64
+
+	mu      sync.Mutex
+	fetched int
+}
+
+func (f *linChainFetcher) IsBlockAvailable(uint64) bool { return true }
+
+func (f *linChainFetcher) Fetch(ctx context.Context, c any, num uint64) (*pbbstream.Block, bool, error) {
+	// higher block number => shorter delay => completes earlier (scrambled completion order)
+	time.Sleep(time.Duration(f.maxBlock-num+1) * 5 * time.Millisecond)
+	f.mu.Lock()
+	f.fetched++
+	f.mu.Unlock()
+	return blk(fmt.Sprintf("%da", num), fmt.Sprintf("%da", num-1), f.libNum), false, nil
+}
+
+func TestBlockPoller_parallelFetchPreservesOrder(t *testing.T) {
+	const first, lib, stop = uint64(100), uint64(100), uint64(110)
+
+	expect := make([]*pbbstream.Block, 0, stop-first)
+	for n := first; n < stop; n++ {
+		expect = append(expect, blk(fmt.Sprintf("%da", n), fmt.Sprintf("%da", n-1), lib))
+	}
+
+	fetcher := &linChainFetcher{libNum: lib, maxBlock: stop}
+	finalizer := newTestBlockFinalizer(t, expect)
+
+	clients := rpc.NewClients[any](time.Second, rpc.NewRollingStrategyAlwaysUseFirst[any](), zap.NewNop())
+	clients.Add(new(any))
+
+	poller := New[any](fetcher, finalizer, clients)
+	poller.fetchBlockRetryCount = 0
+
+	stopBlock := stop
+	// blockFetchBatchSize=10: blocks 100..109 are fetched concurrently and complete
+	// out of order, but must be fired in order. finalizer.check asserts both the
+	// exact set and the order.
+	require.NoError(t, poller.Run(first, &stopBlock, 10))
+
+	finalizer.check(t)
+}

--- a/blockpoller/poller_parallel_test.go
+++ b/blockpoller/poller_parallel_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	pbbstream "github.com/streamingfast/bstream/pb/sf/bstream/v1"
@@ -17,7 +18,8 @@ import (
 // to exercise parallel block fetching (blockFetchBatchSize > 1). It deliberately
 // delays LOWER block numbers MORE than higher ones, so the concurrent fetches
 // complete out of order — the poller must still fire blocks to the handler in
-// strict ascending order.
+// strict ascending order. The sleep uses the synctest fake clock, so completion
+// order is scrambled deterministically with no real wall-clock delay.
 type linChainFetcher struct {
 	libNum   uint64
 	maxBlock uint64
@@ -38,27 +40,32 @@ func (f *linChainFetcher) Fetch(ctx context.Context, c any, num uint64) (*pbbstr
 }
 
 func TestBlockPoller_parallelFetchPreservesOrder(t *testing.T) {
-	const first, lib, stop = uint64(100), uint64(100), uint64(110)
+	synctest.Test(t, func(t *testing.T) {
+		const first, lib, stop = uint64(100), uint64(100), uint64(110)
 
-	expect := make([]*pbbstream.Block, 0, stop-first)
-	for n := first; n < stop; n++ {
-		expect = append(expect, blk(fmt.Sprintf("%da", n), fmt.Sprintf("%da", n-1), lib))
-	}
+		expect := make([]*pbbstream.Block, 0, stop-first)
+		for n := first; n < stop; n++ {
+			expect = append(expect, blk(fmt.Sprintf("%da", n), fmt.Sprintf("%da", n-1), lib))
+		}
 
-	fetcher := &linChainFetcher{libNum: lib, maxBlock: stop}
-	finalizer := newTestBlockFinalizer(t, expect)
+		fetcher := &linChainFetcher{libNum: lib, maxBlock: stop}
+		finalizer := newTestBlockFinalizer(t, expect)
 
-	clients := rpc.NewClients[any](time.Second, rpc.NewRollingStrategyAlwaysUseFirst[any](), zap.NewNop())
-	clients.Add(new(any))
+		clients := rpc.NewClients[any](time.Second, rpc.NewRollingStrategyAlwaysUseFirst[any](), zap.NewNop())
+		clients.Add(new(any))
 
-	poller := New[any](fetcher, finalizer, clients)
-	poller.fetchBlockRetryCount = 0
+		poller := New[any](fetcher, finalizer, clients)
+		// Shut down so the background monitoring goroutine exits; otherwise
+		// synctest.Test would report a leaked (durably blocked) goroutine.
+		defer poller.Shutdown(nil)
+		poller.fetchBlockRetryCount = 0
 
-	stopBlock := stop
-	// blockFetchBatchSize=10: blocks 100..109 are fetched concurrently and complete
-	// out of order, but must be fired in order. finalizer.check asserts both the
-	// exact set and the order.
-	require.NoError(t, poller.Run(first, &stopBlock, 10))
+		stopBlock := stop
+		// blockFetchBatchSize=10: blocks 100..109 are fetched concurrently and complete
+		// out of order, but must be fired in order. finalizer.check asserts both the
+		// exact set and the order.
+		require.NoError(t, poller.Run(first, &stopBlock, 10))
 
-	finalizer.check(t)
+		finalizer.check(t)
+	})
 }

--- a/rpc/clients.go
+++ b/rpc/clients.go
@@ -57,12 +57,15 @@ func (c *Clients[C]) Add(client C) {
 	c.clients = append(c.clients, client)
 }
 func WithClientsContext[C any, V any](clients *Clients[C], ctx context.Context, f func(context.Context, C) (v V, err error)) (v V, err error) {
-	clients.lock.Lock()
-	defer clients.lock.Unlock()
 	var errs error
 
+	// The lock only guards the rolling-strategy state (client selection), NOT the
+	// call to f. Holding it across f serializes all concurrent callers (e.g. the
+	// block poller's parallel-prefetch workers), defeating the parallelism.
+	clients.lock.Lock()
 	clients.rollingStrategy.reset()
 	client, err := clients.rollingStrategy.next(clients)
+	clients.lock.Unlock()
 	if err != nil {
 		errs = multierror.Append(errs, err)
 		return v, errs
@@ -76,7 +79,9 @@ func WithClientsContext[C any, V any](clients *Clients[C], ctx context.Context, 
 
 		if err != nil {
 			errs = multierror.Append(errs, err)
+			clients.lock.Lock()
 			client, err = clients.rollingStrategy.next(clients)
+			clients.lock.Unlock()
 			if err != nil {
 				errs = multierror.Append(errs, err)
 				return v, errs

--- a/rpc/clients.go
+++ b/rpc/clients.go
@@ -59,9 +59,7 @@ func (c *Clients[C]) Add(client C) {
 func WithClientsContext[C any, V any](clients *Clients[C], ctx context.Context, f func(context.Context, C) (v V, err error)) (v V, err error) {
 	var errs error
 
-	// The lock only guards the rolling-strategy state (client selection), NOT the
-	// call to f. Holding it across f serializes all concurrent callers (e.g. the
-	// block poller's parallel-prefetch workers), defeating the parallelism.
+	// guard the rolling-strategy state (client selection), NOT the call to f
 	clients.lock.Lock()
 	clients.rollingStrategy.reset()
 	client, err := clients.rollingStrategy.next(clients)

--- a/rpc/clients_concurrent_test.go
+++ b/rpc/clients_concurrent_test.go
@@ -1,0 +1,52 @@
+package rpc
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// TestWithClients_doesNotSerialize guards the fix in WithClientsContext: the
+// clients lock must only protect rolling-strategy selection, NOT the call to
+// f. If the lock is (re)introduced around f, concurrent callers serialize and
+// only one can be inside f at a time — this test then deadlocks until the
+// per-entry timeout fires and fails.
+func TestWithClients_doesNotSerialize(t *testing.T) {
+	clients := NewClients[any](time.Second, NewStickyRollingStrategy[any](), zap.NewNop())
+	for i := 0; i < 4; i++ {
+		clients.Add(new(any))
+	}
+
+	const n = 4
+	entered := make(chan struct{}, n)
+	release := make(chan struct{})
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = WithClients(clients, func(ctx context.Context, c any) (any, error) {
+				entered <- struct{}{} // signal we're inside f
+				<-release             // hold here until every caller is inside f
+				return nil, nil
+			})
+		}()
+	}
+
+	// All n callers must be able to be inside f at the same time. If the lock is
+	// held across f, only the first gets in and the rest block on the mutex.
+	for i := 0; i < n; i++ {
+		select {
+		case <-entered:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("only %d/%d callers entered f concurrently: WithClients is serializing on the clients lock", i, n)
+		}
+	}
+
+	close(release)
+	wg.Wait()
+}

--- a/rpc/clients_concurrent_test.go
+++ b/rpc/clients_concurrent_test.go
@@ -3,7 +3,9 @@ package rpc
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"go.uber.org/zap"
@@ -12,41 +14,47 @@ import (
 // TestWithClients_doesNotSerialize guards the fix in WithClientsContext: the
 // clients lock must only protect rolling-strategy selection, NOT the call to
 // f. If the lock is (re)introduced around f, concurrent callers serialize and
-// only one can be inside f at a time — this test then deadlocks until the
-// per-entry timeout fires and fails.
+// only one can be inside f at a time.
+//
+// We run inside a synctest bubble so the assertion is deterministic: once all
+// callers are inside f and durably blocked on `release`, synctest.Wait returns
+// and we can read exactly how many made it in. If the lock is held across f,
+// only the first caller reaches f (the rest block on the mutex) and the bubble
+// never reaches an all-durably-blocked state, so the test hangs and fails.
 func TestWithClients_doesNotSerialize(t *testing.T) {
-	clients := NewClients[any](time.Second, NewStickyRollingStrategy[any](), zap.NewNop())
-	for i := 0; i < 4; i++ {
-		clients.Add(new(any))
-	}
-
-	const n = 4
-	entered := make(chan struct{}, n)
-	release := make(chan struct{})
-
-	var wg sync.WaitGroup
-	for i := 0; i < n; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			_, _ = WithClients(clients, func(ctx context.Context, c any) (any, error) {
-				entered <- struct{}{} // signal we're inside f
-				<-release             // hold here until every caller is inside f
-				return nil, nil
-			})
-		}()
-	}
-
-	// All n callers must be able to be inside f at the same time. If the lock is
-	// held across f, only the first gets in and the rest block on the mutex.
-	for i := 0; i < n; i++ {
-		select {
-		case <-entered:
-		case <-time.After(2 * time.Second):
-			t.Fatalf("only %d/%d callers entered f concurrently: WithClients is serializing on the clients lock", i, n)
+	synctest.Test(t, func(t *testing.T) {
+		clients := NewClients[any](time.Second, NewStickyRollingStrategy[any](), zap.NewNop())
+		for i := 0; i < 4; i++ {
+			clients.Add(new(any))
 		}
-	}
 
-	close(release)
-	wg.Wait()
+		const n = 4
+		var inside atomic.Int32
+		release := make(chan struct{})
+
+		var wg sync.WaitGroup
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, _ = WithClients(clients, func(ctx context.Context, c any) (any, error) {
+					inside.Add(1) // record that we're inside f
+					<-release      // hold here until every caller is inside f
+					return nil, nil
+				})
+			}()
+		}
+
+		// Block until every caller goroutine is durably blocked. With the lock
+		// correctly scoped, all n reach f and park on <-release; with the lock
+		// held across f, only one does and the rest sit on the mutex.
+		synctest.Wait()
+
+		if got := inside.Load(); got != n {
+			t.Fatalf("only %d/%d callers entered f concurrently: WithClients is serializing on the clients lock", got, n)
+		}
+
+		close(release)
+		wg.Wait()
+	})
 }


### PR DESCRIPTION
Required by https://github.com/streamingfast/firehose-ethereum/pull/159

## Problem

`WithClientsContext` held `clients.lock` for the **entire duration of the fetch callback `f`**, not just while selecting a client:

```go
clients.lock.Lock()
defer clients.lock.Unlock()
...
v, err := f(ctx, client)   // seconds of network I/O, lock still held
```

The mutex is only meant to guard the rolling-strategy state (which endpoint to hand out next, for failover). Holding it across `f` means **every concurrent caller serializes** on it.

The block poller's parallel-prefetch path (`blockpoller` → `dhammer.Nailer`, used when `blockFetchBatchSize > 1`) runs each fetch through `WithClients`, so all prefetch workers queued on this single lock. Result: "parallel" block fetching ran strictly one-at-a-time, and a `block-fetch-batch-size` knob had no effect. Especially painful on chains with large blocks 

## Fix

Scope the lock to **only** the rolling-strategy selection, releasing it before calling `f`:

```go
clients.lock.Lock()
clients.rollingStrategy.reset()
client, err := clients.rollingStrategy.next(clients)
clients.lock.Unlock()
...
v, err := f(ctx, client)   // runs concurrently across callers
```

Also makes `BlockPoller.fetching` an `atomic.Bool` (`CompareAndSwap`): it was read in the run loop and written in the spawned prefetch goroutine without synchronization — a pre-existing data race flagged by `go test -race` once the concurrent path is exercised. CAS is race-clean and guarantees exactly one prefetch goroutine in flight.

## Ordering is preserved

Blocks are fired strictly in ascending order regardless of fetch completion order: `dhammer.Nailer` linearizes output in input order, and the poll loop fires one block at a time from the single run goroutine.

## Measured impact

End-to-end through the real `reader-node` pipeline (megaETH, one-block files/min):

| `block-fetch-batch-size` | throughput |
|---|---|
| 1 (current) | ~0.5 blk/s |
| 10 | ~3.3 blk/s (**6.7x**) |
| 16 | ~4.6 blk/s |
| 32 | ~5.7 blk/s |
| 64 | ~7.1 blk/s |

At batch=1 the poller can't keep up with the ~1 blk/s chain; batch>=8 keeps up and catches up. Near-linear to ~16, then diminishing returns.

## Tests

- `rpc.TestWithClients_doesNotSerialize` — 4 concurrent callers must all be inside `f` at once; fails (times out) if the lock is ever re-held across `f`.
- `blockpoller.TestBlockPoller_parallelFetchPreservesOrder` — `blockFetchBatchSize=10` with out-of-order fetch completion; asserts blocks still fire in strict ascending order.

Both pass under `go test -race`.


