### PR TITLE
ci: skip Slack steps for fork PRs in docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Get Slack ID
         id: get-slack-id
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: |
           SLACK_IDS=$(echo "$SLACK_IDS" | sed 's/\\//g')
           SLACK_ID=$(echo "$SLACK_IDS" | jq -r '.["${{ github.actor }}"]')
@@ -118,7 +119,7 @@ jobs:
 
       - name: Get Job ID from GH API
         id: get_job_id
-        if: ${{ failure() }}
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -127,7 +128,7 @@ jobs:
           echo "job_id=$job_id" >> $GITHUB_OUTPUT
 
       - name: Notify build failure on Slack
-        if: ${{ failure() }}
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         uses: Ilshidur/action-slack@2.1.0


### PR DESCRIPTION
## Summary

- Skip `Get Slack ID` step for fork PRs — prevents jq parse error when `SLACK_IDS` is empty (org vars unavailable for forks)
- Skip `Get Job ID from GH API` step on failure for fork PRs
- Skip `Notify build failure on Slack` step on failure for fork PRs

All three use the same guard pattern established in #155 for the `Check SLACK_IDS` step:
```
if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
```

The `push` and `slack-notifications` jobs were already gated correctly at the job level.

## Test plan

- [ ] Verify fork PR CI run completes without failures in the `setup` job
- [ ] Verify no Slack notifications fire for fork PR build failures
- [ ] Verify internal PR and push/tag events still trigger Slack notifications as before