### PR TITLE
fix(docker): patch CVE-2026-45447 (openssl HIGH) in runtime image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 - Substreams: fix `Sinker.requestActiveStartBlock` not being set when the handler implements `SinkerSessionInitHandler`, which previously caused `ProgressMessageLastContiguousBlock` to be incorrect for production-mode mapper stages.
 - Substreams: detect reorgs in executed partial blocks even when the transaction hashes are identical. Previously a recomputed block whose only difference was its state (same, equally-ordered transactions) was not detected as replaced, so no reorg was triggered; more block fields are now validated to catch this.
 
+### Security
+
+- Docker: the runtime image now runs `apt-get upgrade` and clears the apt cache during build, pulling in available OS security patches (fixes `CVE-2026-45447` in `openssl`).
+
 ## v1.14.5
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM ubuntu:24.04
 ARG TARGETPLATFORM
 
 # gettext-base is needed for envsubst
-RUN apt-get update && apt-get -y install ca-certificates htop iotop sysstat strace lsof curl jq tzdata file gettext-base
+RUN apt-get update && apt-get -y upgrade && apt-get -y install ca-certificates htop iotop sysstat strace lsof curl jq tzdata file gettext-base && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Docker Scout flagged a **HIGH** vulnerability — `CVE-2026-45447` in `openssl` `3.0.13-0ubuntu3.9` — against the `ubuntu:24.04` base image used by the runtime stage. Ubuntu ships a fix in `3.0.13-0ubuntu3.11`.

## Fix

Add `apt-get -y upgrade` (and `rm -rf /var/lib/apt/lists/*` cleanup) to the runtime stage in `Dockerfile`, so the image pulls available OS security patches at build time.

## Verification

Built the image locally and rescanned with Docker Scout:

| | Base `ubuntu:24.04` | After build |
|---|---|---|
| Critical / High | 0C / **1H** | 0C / **0H** |
| Medium / Low | 26M / 11L | 12M / 4L |

- `openssl` `3.0.13-0ubuntu3.9` → `3.0.13-0ubuntu3.11` — **CVE-2026-45447 fixed**.
- `apt-get upgrade` also cleared 14 medium + 7 low. Remaining 12M/4L have no published Ubuntu fix yet.

## Notes

- `--no-install-recommends` intentionally left off to avoid changing which packages land in the image.
- CHANGELOG.md updated under `### Security`.

Ref: https://github.com/streamingfast/firehose-core/pull/158#issuecomment-4681161670