### PR TITLE
Add per-source block time drift metric to relayer

### DIFF
--- a/relayer/metrics/source_drift.go
+++ b/relayer/metrics/source_drift.go
@@ -1,0 +1,55 @@
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/streamingfast/dmetrics"
+)
+
+// SourceHeadBlockTimeDrift tracks, per source, the time elapsed since the
+// last block received from that source. The drift is computed at scrape
+// time, so it keeps growing while a source is silent.
+var SourceHeadBlockTimeDrift = newSourceHeadTimeDrift("relayer")
+
+type sourceHeadTimeDrift struct {
+	desc *prometheus.Desc
+
+	mu             sync.Mutex
+	lastBlockTimes map[string]time.Time
+}
+
+func newSourceHeadTimeDrift(app string) *sourceHeadTimeDrift {
+	return &sourceHeadTimeDrift{
+		desc: prometheus.NewDesc(
+			"source_head_block_time_drift",
+			"Number of seconds away from real-time, by source",
+			[]string{"source"},
+			prometheus.Labels{"app": app},
+		),
+		lastBlockTimes: make(map[string]time.Time),
+	}
+}
+
+func (s *sourceHeadTimeDrift) SetBlockTime(source string, blockTime time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastBlockTimes[source] = blockTime
+}
+
+func (s *sourceHeadTimeDrift) Describe(ch chan<- *prometheus.Desc) {
+	ch <- s.desc
+}
+
+func (s *sourceHeadTimeDrift) Collect(ch chan<- prometheus.Metric) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for source, blockTime := range s.lastBlockTimes {
+		ch <- prometheus.MustNewConstMetric(s.desc, prometheus.GaugeValue, time.Since(blockTime).Seconds(), source)
+	}
+}
+
+func init() {
+	dmetrics.PrometheusRegister(SourceHeadBlockTimeDrift)
+}

--- a/relayer/metrics/source_drift_test.go
+++ b/relayer/metrics/source_drift_test.go
@@ -1,0 +1,81 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func gatherDrift(t *testing.T, reg *prometheus.Registry) map[string]float64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+
+	out := make(map[string]float64)
+	for _, mf := range mfs {
+		if mf.GetName() != "source_head_block_time_drift" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			var source string
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "source" {
+					source = lp.GetValue()
+				}
+			}
+			out[source] = m.GetGauge().GetValue()
+		}
+	}
+	return out
+}
+
+func TestSourceHeadTimeDriftGrowsWhileSilent(t *testing.T) {
+	drift := newSourceHeadTimeDrift("relayer")
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(drift))
+
+	drift.SetBlockTime("reader-1", time.Now().Add(-2*time.Second))
+	drift.SetBlockTime("reader-2", time.Now())
+
+	first := gatherDrift(t, reg)
+	require.Contains(t, first, "reader-1")
+	require.Contains(t, first, "reader-2")
+	assert.InDelta(t, 2.0, first["reader-1"], 0.5)
+
+	wait := 200 * time.Millisecond
+	time.Sleep(wait)
+
+	// no SetBlockTime in between: drift must grow by the elapsed time
+	second := gatherDrift(t, reg)
+	assert.InDelta(t, first["reader-1"]+wait.Seconds(), second["reader-1"], 0.1)
+	assert.InDelta(t, first["reader-2"]+wait.Seconds(), second["reader-2"], 0.1)
+
+	// a new block resets the drift for that source only
+	drift.SetBlockTime("reader-1", time.Now())
+	third := gatherDrift(t, reg)
+	assert.Less(t, third["reader-1"], 0.1)
+	assert.Greater(t, third["reader-2"], wait.Seconds())
+}
+
+func TestSourceHeadTimeDriftLabels(t *testing.T) {
+	drift := newSourceHeadTimeDrift("relayer")
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(drift))
+
+	drift.SetBlockTime("reader-1", time.Now())
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	require.Len(t, mfs, 1)
+	require.Len(t, mfs[0].GetMetric(), 1)
+
+	labels := make(map[string]string)
+	for _, lp := range mfs[0].GetMetric()[0].GetLabel() {
+		labels[lp.GetName()] = lp.GetValue()
+	}
+	assert.Equal(t, "relayer", labels["app"])
+	assert.Equal(t, "reader-1", labels["source"])
+}

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -109,6 +109,7 @@ func NewMultiplexedSource(handler bstream.Handler, sources []SourceAddr, maxSour
 			gate := bstream.NewRealtimeGate(maxSourceLatency, subHandler, bstream.GateOptionWithLogger(logger))
 			var upstreamHandler bstream.Handler
 			upstreamHandler = bstream.HandlerFunc(func(blk *pbbstream.Block, obj interface{}) error {
+				metrics.SourceHeadBlockTimeDrift.SetBlockTime(sourceName, blk.Timestamp.AsTime())
 				if ztrace.Enabled() {
 					logger.Debug("received block", zap.Uint64("number", blk.Number), zap.String("id", blk.Id), zap.Int64("latency_ms", time.Since(blk.Timestamp.AsTime()).Milliseconds()))
 				}


### PR DESCRIPTION
Exposes source_head_block_time_drift{app="relayer",source=...}, computed
at scrape time so it keeps growing while a source is silent.

this can be useful to detect if a 'rescuer' should be added
