### PR TITLE
feat(tools): improve substreams logs connection and reexec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 - Bumped `dstore`: S3 store now suppresses the SDK's checksum validation warnings (sets `DisableLogOutputChecksumValidationSkipped` to `true`) and updates the AWS S3 SDK to a newer version.
 - Substreams: the tier1 job scheduler no longer slows down on very large reprocessings (100_000s of segments). `NextJob` and `AllStoresCompleted` used to rescan the whole completed-segment prefix on every scheduling event (O(segments²) over a run) and now advance a forward-only cursor (O(1) amortized). Progress reporting (`UpdateStats`) builds each stage's ranges in a single sort-free pass, the scheduler event loop drops per-message overhead (debug-state env var read once at startup, debug log fields built only when debug logging is enabled), and the cached-output streaming buffer appends and checks for flushing under a single lock per block.
 - Substreams: `SUBSTREAMS_STORE_SIZE_LIMIT` is now passed from tier1 to tier2; when set on tier1 it overrides the tier2 env var value.
+- `tools substreams logs connection`: the Request section now always shows the `Cursor:` field, displaying `None` when no cursor was provided.
 
 ### Added
 
 - Reader: two prometheus gauges to watch how close blocks read out of the node are to the `reader-node-line-buffer-size` hard limit: `reader_node_max_read_block_size_bytes` (high-water mark of the largest line/block read) and `reader_node_line_buffer_size_bytes` (the configured limit).
+- `tools substreams logs reexec`: new `--production-mode` flag to override the execution mode of the re-exec'ed request; when not provided, keeps the original request's mode, `--production-mode` forces production mode, `--production-mode=false` forces development mode.
 
 ### Fixed
 

--- a/cmd/tools/substreams/logs_connection.go
+++ b/cmd/tools/substreams/logs_connection.go
@@ -224,6 +224,8 @@ func printConnectionRequest(request, stats *logs.LogEntry) {
 				cur = cur[:24] + "..."
 			}
 			fmt.Printf("%s %s\n", stylex.Label("Cursor:"), stylex.Dim(cur))
+		} else {
+			fmt.Printf("%s %s\n", stylex.Label("Cursor:"), stylex.Dim("None"))
 		}
 		printField("User ID:", request.UserID)
 		printField("IP address:", request.IPAddress)

--- a/cmd/tools/substreams/logs_reexec.go
+++ b/cmd/tools/substreams/logs_reexec.go
@@ -72,6 +72,7 @@ The date-range argument(s) accept various formats:
 	cmd.MarkFlagRequired("gcp-project")
 
 	cmd.Flags().String("cursor", "", "Starting cursor, overrides the cursor from the log entry")
+	cmd.Flags().Bool("production-mode", true, "Override execution mode: 'true' forces production mode, 'false' forces development mode; when not provided, keeps the original request's mode")
 	cmd.Flags().Bool("insecure", false, "Allow insecure TLS connections to the endpoint")
 	cmd.Flags().Bool("plain-text", false, "Use unencrypted plain-text connection to the endpoint")
 	cmd.Flags().StringP("output", "o", "clock", "Output format for blocks: clock, json, or protojson")
@@ -90,6 +91,7 @@ func runReexec(ctx context.Context, args []string, cmd *cobra.Command, logger *z
 	stateStore := sflags.MustGetString(cmd, "state-store")
 	endpointFlag := sflags.MustGetString(cmd, "endpoint")
 	cursorFlag := sflags.MustGetString(cmd, "cursor")
+	productionModeFlag, productionModeFlagProvided := sflags.MustGetBoolProvided(cmd, "production-mode")
 	apiKey := sflags.MustGetString(cmd, "api-key")
 	if apiKey == "" {
 		apiKey = os.Getenv("SUBSTREAMS_API_KEY")
@@ -161,7 +163,12 @@ func runReexec(ctx context.Context, args []string, cmd *cobra.Command, logger *z
 	} else {
 		fmt.Printf("%s %s\n", stylex.Label("Stop block:"), stylex.Dim("open-ended"))
 	}
-	fmt.Printf("%s %v\n", stylex.Label("Production mode:"), req.ProductionMode)
+	if productionModeFlagProvided {
+		req.ProductionMode = productionModeFlag
+		fmt.Printf("%s %v %s\n", stylex.Label("Production mode:"), req.ProductionMode, stylex.Dim("(forced by --production-mode)"))
+	} else {
+		fmt.Printf("%s %v\n", stylex.Label("Production mode:"), req.ProductionMode)
+	}
 	fmt.Printf("%s %v\n", stylex.Label("Final blocks only:"), req.FinalBlocksOnly)
 	if req.Namespace != "" {
 		fmt.Printf("%s %s\n", stylex.Label("Namespace:"), stylex.Value(req.Namespace))


### PR DESCRIPTION
## Summary

Two improvements to the `firecore tools substreams logs` commands.

### `connection`
- The Request section now **always** prints the `Cursor:` field, showing `None` when the original request carried no cursor (previously the field was hidden entirely).

### `reexec`
- New `--production-mode` flag to override the execution mode of the re-exec'ed request:
  - **not provided** → keep the original request's mode (unchanged behavior)
  - `--production-mode` (true) → force production mode
  - `--production-mode=false` → force development mode
- Implemented with `sflags.MustGetBoolProvided`, so the "unset" case is detected natively without a string sentinel. The override mutates the resolved request, so the printed mode, the sinker mode, and the generated `substreams run` hint all reflect it.

## Changelog
Updated under `## Unreleased`.