### PR TITLE
fix: log forkable hub/forkable lines under the owning component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 - Substreams: fix some edge cases with partial blocks that would prevent proper detection of invalid partials that need to be undone, or causing spurious UNDO events.
 - Substreams: fix `Sinker.requestActiveStartBlock` not being set when the handler implements `SinkerSessionInitHandler`, which previously caused `ProgressMessageLastContiguousBlock` to be incorrect for production-mode mapper stages.
 - Substreams: detect reorgs in executed partial blocks even when the transaction hashes are identical. Previously a recomputed block whose only difference was its state (same, equally-ordered transactions) was not detected as replaced, so no reorg was triggered; more block fields are now validated to catch this.
+- Logging: `processing block` (and other bstream forkable hub/forkable lines) are now logged under the owning component's logger (`relayer`, `firehose`, `merger`, ...) instead of all appearing under the generic `bstream` logger, making it possible to tell which component emitted each line. Requires bstream `hub.WithLogger`.
 
 ### Security
 

--- a/firehose/app/firehose/app.go
+++ b/firehose/app/firehose/app.go
@@ -130,7 +130,7 @@ func (a *App) Run() error {
 			)
 		})
 
-		forkableHub = hub.NewForkableHub(liveSourceFactory, 500, oneBlocksStore)
+		forkableHub = hub.NewForkableHubWithOptions(liveSourceFactory, 500, oneBlocksStore, []hub.Option{hub.WithLogger(a.logger)})
 		forkableHub.OnTerminated(a.Shutdown)
 
 		go forkableHub.Run()

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
-	github.com/streamingfast/bstream v0.0.2-0.20260610182139-c1572d2f51c6
+	github.com/streamingfast/bstream v0.0.2-0.20260611155534-4edda1cff251
 	github.com/streamingfast/cli v0.0.4-0.20250815192146-d8a233ec3d0b
 	github.com/streamingfast/dauth v0.0.0-20260318230957-4ab1e1d2ebc3
 	github.com/streamingfast/derr v0.0.0-20250814163534-bd7407bd89d7
@@ -41,7 +41,7 @@ require (
 	github.com/streamingfast/payment-gateway v0.0.0-20260527144655-d0576d2a4ee3
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0
-	github.com/streamingfast/substreams v1.18.6-0.20260610195629-c3f50ce6cf6d
+	github.com/streamingfast/substreams v1.18.6-0.20260612185556-609bd2f621f2
 	github.com/stretchr/testify v1.11.1
 	github.com/test-go/testify v1.1.4
 	github.com/testcontainers/testcontainers-go v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -2308,6 +2308,8 @@ github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag
 github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/streamingfast/bstream v0.0.2-0.20260610182139-c1572d2f51c6 h1:8LMg/E/Rw2GljnTgfiU0DA/nD9aD7xYCMnJD0/FHCys=
 github.com/streamingfast/bstream v0.0.2-0.20260610182139-c1572d2f51c6/go.mod h1:6IkpMw6g2z+E4gH2DJkm6vsQfZ8Y/WdYdYWjsLJIYr4=
+github.com/streamingfast/bstream v0.0.2-0.20260611155534-4edda1cff251 h1:hAYplhkYB/yTWJ6hDkO+mvYz8ETveBk9rZsOgta3+7U=
+github.com/streamingfast/bstream v0.0.2-0.20260611155534-4edda1cff251/go.mod h1:Asuul2Rnxln0Vk6eY869AZ2UybIQcB7eYOQAIhfQHzE=
 github.com/streamingfast/cli v0.0.4-0.20250815192146-d8a233ec3d0b h1:ztYeX3/5rg2tV2EU7edcrcHzMz6wUbdJB+LqCrP5W8s=
 github.com/streamingfast/cli v0.0.4-0.20250815192146-d8a233ec3d0b/go.mod h1:o9R/tjNON01X2mgWL5qirl2MV6xQ4EZI5D504ST3K/M=
 github.com/streamingfast/dauth v0.0.0-20260318230957-4ab1e1d2ebc3 h1:Zo2daSGDUPoK32w9G1e9fZO3Q6b5Cvu5ZojdoD/Wgp8=
@@ -2365,6 +2367,8 @@ github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
 github.com/streamingfast/substreams v1.18.6-0.20260610195629-c3f50ce6cf6d h1:+DqtyQ1RQbbt84tInF1R9s3zqk9Gbum0SjtsAWRffow=
 github.com/streamingfast/substreams v1.18.6-0.20260610195629-c3f50ce6cf6d/go.mod h1:DZqsrFL1s5N1RAsC8TPN5x9k+n0iRW5WyiQiqvL1jrw=
+github.com/streamingfast/substreams v1.18.6-0.20260612185556-609bd2f621f2 h1:BoYWZ65wHDXn6U4ga7dtnunLZshUHuyCTFeesaFhlpw=
+github.com/streamingfast/substreams v1.18.6-0.20260612185556-609bd2f621f2/go.mod h1:KA2JAM49Xxs9KFkogjfniykSmuUJAWX4+TL58/5Q5Xk=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=

--- a/merger/bundler.go
+++ b/merger/bundler.go
@@ -151,6 +151,7 @@ func (b *Bundler) forkedBlocksInCurrentBundle() (out []*bstream.OneBlockFile) {
 
 func (b *Bundler) Reset(nextBase uint64, lib bstream.BlockRef) {
 	options := []forkable.Option{
+		forkable.WithLogger(b.logger),
 		forkable.WithFilters(bstream.StepIrreversible),
 		forkable.HoldBlocksUntilLIB(),
 		forkable.WithWarnOnUnlinkableBlocks(100), // don't warn too soon, sometimes oneBlockFiles are uploaded out of order from mindreader (on remote I/O)

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -85,7 +85,7 @@ func NewRelayer(
 		r.liveSourceFactory,
 		10,
 		oneBlocksStore,
-		[]hub.Option{hub.WithMaxConsecutiveUnlinkableBlocks(5)},
+		[]hub.Option{hub.WithMaxConsecutiveUnlinkableBlocks(5), hub.WithLogger(zlog)},
 		options...,
 	)
 


### PR DESCRIPTION
## Problem

The bstream `ForkableHub` and the merger bundler forkable used the default `bstream` package logger. As a result, identical `processing block` lines from the relayer, firehose and merger all appeared under the generic `bstream` logger, making it impossible to tell which component emitted each one.

## Change

Pass each component's logger so block-level lines are attributed correctly:
- relayer + firehose app: bstream `hub.WithLogger` (`NewForkableHub` → `NewForkableHubWithOptions`)
- merger bundler: `forkable.WithLogger`

Bumps:
- `bstream` → `v0.0.2-0.20260611155534-4edda1cff251` (adds `hub.WithLogger`)
- `substreams` → `v1.18.6-0.20260612185556-609bd2f621f2` (tier1 logs under `tier1`)

## Depends on (both merged)

- streamingfast/bstream#56
- streamingfast/substreams#802

## Test

`go build ./...` + `go test ./relayer/... ./firehose/... ./merger/...` ✅