### PR TITLE
Bump substreams to latest develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Operators, you should copy/paste content of this content straight to your projec
 
 If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you should copy the content between those 2 version to your own repository, replacing placeholder value `fire{chain}` with your chain's own binary.
 
+## Unreleased
+
+### Changed
+
+- Bumped `substreams` to latest `develop`.
+  - Server: `tier1` calls to hosted foundational stores now forward the `x-organization-id` identity header (alongside the existing trusted headers), so a store's internal trust-based listener can authorize the request without an end-user JWT. This fixes `Unauthenticated: required authorization token not found` errors when reading from hosted foundational stores resolved via the control-plane registry.
+  - Server: foundational store calls that fail with authentication errors, organization id mismatch, or prolonged unreachability now bubble up to the user as a non-deterministic (uncached) error instead of retrying until the global deadline. Transient unavailability is still retried (~30s) to absorb blips and rolling restarts.
+
 ## v1.15.0
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/streamingfast/payment-gateway v0.0.0-20260527144655-d0576d2a4ee3
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0
-	github.com/streamingfast/substreams v1.19.1-0.20260629190659-dcc219641f36
+	github.com/streamingfast/substreams v1.19.1-0.20260630163124-bb675e471f74
 	github.com/stretchr/testify v1.11.1
 	github.com/test-go/testify v1.1.4
 	github.com/testcontainers/testcontainers-go v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -2340,8 +2340,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.19.1-0.20260629190659-dcc219641f36 h1:E7WR4O8dsiIfkURCeUtW5HRSJwu0WmD/rEcurKxSHmI=
-github.com/streamingfast/substreams v1.19.1-0.20260629190659-dcc219641f36/go.mod h1:fQCdmwjeF+W2MhLEmFG1tEnsp85dwVv5vDgbaRcuzeQ=
+github.com/streamingfast/substreams v1.19.1-0.20260630163124-bb675e471f74 h1:GWDP6JkSSd8NLDk05H2LUUbXzB5RSddFwZsUk5wFAck=
+github.com/streamingfast/substreams v1.19.1-0.20260630163124-bb675e471f74/go.mod h1:fQCdmwjeF+W2MhLEmFG1tEnsp85dwVv5vDgbaRcuzeQ=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=


### PR DESCRIPTION
Bumps `substreams` to latest `develop` (`bb675e47`).

### Changes pulled in
- Server: `tier1` calls to hosted foundational stores now forward the `x-organization-id` identity header so trust-based listeners can authorize without an end-user JWT.
- Server: foundational store calls failing with auth errors, org-id mismatch, or prolonged unreachability now fail fast as non-deterministic (uncached) errors instead of retrying until the global deadline. Transient unavailability still retried (~30s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)