### PR TITLE
merger: configurable one-block-files prune distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 ## Unreleased
 
+### Added
+
+- merger: new `--merger-prune-one-block-files-after` flag (default `100`) controlling how many blocks below the last merged block one-block files are kept before deletion. Raise it so a relayer/firehose that briefly falls behind can still find the one-block files needed to bridge the gap and relink, instead of getting stuck in a reconnect loop or dying with `cannot link block after reconnection, restart required`. Clamped to a minimum of `100` (the bundle size) to preserve the safety margin against deleting not-yet-merged files.
+
 ### Changed
 
 - Bumped `substreams` to latest `develop`.

--- a/cmd/apps/merger.go
+++ b/cmd/apps/merger.go
@@ -21,6 +21,7 @@ func RegisterMergerApp(rootLog *zap.Logger) {
 			cmd.Flags().String("merger-grpc-listen-addr", firecore.MergerServingAddr, "Address to listen for incoming gRPC requests")
 			cmd.Flags().String("merger-http-healthz-addr", firecore.MergerHTTPHealthzAddr, "Address to listen on for the HTTP /healthz endpoint. Set to an empty string to disable. Returns 200 when ready, 503 otherwise.")
 			cmd.Flags().Uint64("merger-prune-forked-blocks-after", 50000, "Number of blocks that must pass before we delete old forks (one-block-files lingering)")
+			cmd.Flags().Uint64("merger-prune-one-block-files-after", 100, "Number of blocks below the last merged block after which we delete merged one-block-files. Increase so a relayer/firehose that fell behind can still bridge the gap and relink (clamped to 100 minimum)")
 			cmd.Flags().Uint64("merger-stop-block", 0, "If non-zero, merger will trigger shutdown when blocks have been merged up to this block")
 			cmd.Flags().Duration("merger-time-between-store-lookups", 1*time.Second, "Delay between source store polling (should be higher for remote storage)")
 			cmd.Flags().Duration("merger-time-between-store-pruning", time.Minute, "Delay between source store pruning loops")
@@ -38,6 +39,7 @@ func RegisterMergerApp(rootLog *zap.Logger) {
 				GRPCListenAddr:               viper.GetString("merger-grpc-listen-addr"),
 				HTTPHealthzListenAddr:        viper.GetString("merger-http-healthz-addr"),
 				PruneForkedBlocksAfter:       viper.GetUint64("merger-prune-forked-blocks-after"),
+				PruneOneBlockFilesAfter:      viper.GetUint64("merger-prune-one-block-files-after"),
 				StorageOneBlockFilesPath:     oneBlocksStoreURL,
 				StorageMergedBlocksFilesPath: mergedBlocksStoreURL,
 				StorageForkedBlocksFilesPath: forkedBlocksStoreURL,

--- a/merger/app/merger/app.go
+++ b/merger/app/merger/app.go
@@ -44,6 +44,8 @@ type Config struct {
 
 	PruneForkedBlocksAfter uint64
 
+	PruneOneBlockFilesAfter uint64
+
 	TimeBetweenPruning time.Duration
 	TimeBetweenPolling time.Duration
 	StopBlock          uint64
@@ -107,6 +109,7 @@ func (a *App) Run() error {
 		bstream.GetProtocolFirstStreamableBlock,
 		bundleSize,
 		a.config.PruneForkedBlocksAfter,
+		a.config.PruneOneBlockFilesAfter,
 		a.config.TimeBetweenPruning,
 		a.config.TimeBetweenPolling,
 		a.config.StopBlock,

--- a/merger/healthz_test.go
+++ b/merger/healthz_test.go
@@ -18,6 +18,7 @@ func TestHealthz_Check(t *testing.T) {
 		1,
 		100,
 		100,
+		100,
 		time.Second,
 		time.Second,
 		0,

--- a/merger/merger.go
+++ b/merger/merger.go
@@ -35,8 +35,9 @@ type Merger struct {
 
 	timeBetweenPolling time.Duration
 
-	timeBetweenPruning   time.Duration
-	pruningDistanceToLIB uint64
+	timeBetweenPruning         time.Duration
+	pruningDistanceToLIB       uint64
+	oneBlockFilesPruneDistance uint64
 
 	bundler *Bundler
 }
@@ -49,20 +50,33 @@ func NewMerger(
 	firstStreamableBlock uint64,
 	bundleSize uint64,
 	pruningDistanceToLIB uint64,
+	oneBlockFilesPruneDistance uint64,
 	timeBetweenPruning time.Duration,
 	timeBetweenPolling time.Duration,
 	stopBlock uint64,
 	maxMergingThreads int,
 ) *Merger {
+	// floor at bundleSize so we never delete not-yet-merged one-block files
+	if oneBlockFilesPruneDistance < bundleSize {
+		if oneBlockFilesPruneDistance != 0 {
+			logger.Warn("one-block-files prune distance is below the bundle size, raising it to the bundle size",
+				zap.Uint64("requested", oneBlockFilesPruneDistance),
+				zap.Uint64("bundle_size", bundleSize),
+			)
+		}
+		oneBlockFilesPruneDistance = bundleSize
+	}
+
 	m := &Merger{
-		Shutter:              shutter.New(),
-		grpcListenAddr:       grpcListenAddr,
-		io:                   io,
-		firstStreamableBlock: firstStreamableBlock,
-		pruningDistanceToLIB: pruningDistanceToLIB,
-		timeBetweenPolling:   timeBetweenPolling,
-		timeBetweenPruning:   timeBetweenPruning,
-		logger:               logger,
+		Shutter:                    shutter.New(),
+		grpcListenAddr:             grpcListenAddr,
+		io:                         io,
+		firstStreamableBlock:       firstStreamableBlock,
+		pruningDistanceToLIB:       pruningDistanceToLIB,
+		oneBlockFilesPruneDistance: oneBlockFilesPruneDistance,
+		timeBetweenPolling:         timeBetweenPolling,
+		timeBetweenPruning:         timeBetweenPruning,
+		logger:                     logger,
 	}
 
 	m.bundler = NewBundler(firstStreamableBlock, stopBlock, firstStreamableBlock, bundleSize, io, maxMergingThreads, m.Shutdown)
@@ -115,7 +129,7 @@ func (m *Merger) startForkedBlocksPruner() {
 
 func (m *Merger) startOldFilesPruner() {
 	m.logger.Info("starting pruning of unused (old) one-block-files",
-		zap.Uint64("pruning_distance_to_lib", m.bundler.bundleSize),
+		zap.Uint64("pruning_distance_to_lib", m.oneBlockFilesPruneDistance),
 		zap.Duration("time_between_pruning", m.timeBetweenPruning),
 	)
 	go func() {
@@ -132,7 +146,7 @@ func (m *Merger) startOldFilesPruner() {
 
 			var toDelete []*bstream.OneBlockFile
 
-			pruningTarget := m.pruningTarget(m.bundler.bundleSize)
+			pruningTarget := m.pruningTarget(m.oneBlockFilesPruneDistance)
 			if pruningTarget == 0 {
 				m.logger.Debug("skipping file deletion until we have a pruning target")
 				continue


### PR DESCRIPTION
The one-block-files pruner hardcoded the prune distance to the bundle size (`100`), so merged one-block files are deleted ~100 blocks behind the merge frontier. A relayer/firehose whose hub falls behind by more than that can't find the one-block files to bridge the gap (the hub has no merged-store fallback), and gets stuck reconnecting — eventually dying with `cannot link block after reconnection, restart required`.

Happened on Hypercore (~14 blocks/s): the relayer fell behind, the ~100-block window is only seconds wide at that rate, and the needed one-block files were already merged-and-deleted. Restarts sometimes helped, sometimes didn't. Raising the prune distance keeps them around long enough to self-recover.

## Change

Add `--merger-prune-one-block-files-after` (default `100`), mirroring `--merger-prune-forked-blocks-after`. Used by `startOldFilesPruner`; forked-blocks pruner untouched. Clamped to a minimum of the bundle size (`100`).

Safe by construction: raising it only makes the pruner more conservative (deletes fewer/older files, never not-yet-merged ones). Default behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
