### PR TITLE
Fix merger lock leak, dead circuit breaker, skip-loop boundary, pipe leak and pruner shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 ### Fixed
 
 - `tools print merged-blocks <store>` no longer truncates its output when a merged-blocks file is missing (open range with no explicit stop, or a bounded range extending past the last available file): with the bumped `bstream` dependency it now prints every available block first, instead of discarding in-flight files on an async shutdown. On an open range it caps the stream at the last available merged-blocks file (found with an `O(log n)` existence probe rather than a full store listing) so it stops cleanly instead of erroring on the expected-missing next file. Also fixes an off-by-one that stopped one block early on a closed range, and a potential unsigned underflow when a closed range ends at block 0.
+- Merger: fixed a lock leak, a dead consecutive-errors circuit breaker, a skip-loop boundary off-by-one, a streaming bundle-reader goroutine leak, and pruners that ignored shutdown.
 
 ## v1.15.0
 

--- a/merger/bundler.go
+++ b/merger/bundler.go
@@ -259,7 +259,9 @@ func (b *Bundler) ProcessBlock(_ *pbbstream.Block, obj interface{}) error {
 	lastBlock := b.irreversibleBlocks[len(b.irreversibleBlocks)-1]
 	b.irreversibleBlocks = []*bstream.OneBlockFile{lastBlock, obf}
 	b.baseBlockNum += b.bundleSize
-	for obf.Num > b.baseBlockNum+b.bundleSize { // skip more merged-block-files
+	// a bundle covers [baseBlockNum, baseBlockNum+bundleSize): a block landing exactly
+	// on baseBlockNum+bundleSize belongs to the *next* bundle, so skip-merge on >= too
+	for obf.Num >= b.baseBlockNum+b.bundleSize { // skip more merged-block-files
 		capturedBase := b.baseBlockNum
 		if b.eg.Stop() { // check before marking in-flight so termination does not leave a stale in-flight entry
 			return errTerminating

--- a/merger/bundler.go
+++ b/merger/bundler.go
@@ -253,16 +253,18 @@ func (b *Bundler) ProcessBlock(_ *pbbstream.Block, obj interface{}) error {
 	})
 
 	b.Lock()
+	defer b.Unlock() // we may return early from inside the skip-forward loop, never leave the lock held
+
 	// we keep the last block of the bundle, only deleting it on next merge, to facilitate joining to one-block-filled hub
 	lastBlock := b.irreversibleBlocks[len(b.irreversibleBlocks)-1]
 	b.irreversibleBlocks = []*bstream.OneBlockFile{lastBlock, obf}
 	b.baseBlockNum += b.bundleSize
 	for obf.Num > b.baseBlockNum+b.bundleSize { // skip more merged-block-files
 		capturedBase := b.baseBlockNum
-		b.markBundleInFlight(capturedBase)
-		if b.eg.Stop() {
+		if b.eg.Stop() { // check before marking in-flight so termination does not leave a stale in-flight entry
 			return errTerminating
 		}
+		b.markBundleInFlight(capturedBase)
 		b.eg.Go(func() error { // lastBlock will be excluded from bundle but is useful to bundler
 			if err := b.io.MergeAndStore(context.Background(), capturedBase, []*bstream.OneBlockFile{lastBlock}); err != nil {
 				go b.shutDownFunc(err) // in a go func so it doesn't block waiting for b.eg
@@ -273,10 +275,8 @@ func (b *Bundler) ProcessBlock(_ *pbbstream.Block, obj interface{}) error {
 		})
 		b.baseBlockNum += b.bundleSize
 	}
-	reachedStop := b.stopBlock != 0 && b.baseBlockNum >= b.stopBlock
-	b.Unlock()
 
-	if reachedStop {
+	if b.stopBlock != 0 && b.baseBlockNum >= b.stopBlock {
 		return ErrStopBlockReached
 	}
 

--- a/merger/bundler_test.go
+++ b/merger/bundler_test.go
@@ -354,3 +354,95 @@ func TestBundlerProcessBlockTerminatingReleasesLock(t *testing.T) {
 		t.Fatal("bundler lock leaked: getSafeBaseBlockNum deadlocked")
 	}
 }
+
+// TestBundlerSkipLoopBoundary verifies bundle attribution when a gap in irreversible
+// blocks ends near a bundle boundary. A bundle covers [base, base+size): a block whose
+// number is exactly base+size belongs to the NEXT bundle, so the skip-forward loop must
+// also fire on equality, otherwise that block gets attributed to the previous bundle.
+func TestBundlerSkipLoopBoundary(t *testing.T) {
+	obf := func(name string) *bstream.OneBlockFile { return bstream.MustNewOneBlockFile(name) }
+
+	commonChain := []*bstream.OneBlockFile{
+		block100(), block101(), block102Final100(), block103Final101(),
+		block104Final102(), block105Final103(), block106Final104(),
+	}
+
+	tests := []struct {
+		name            string
+		gapBlocks       []*bstream.OneBlockFile
+		expectMerged    []uint64
+		expectBase      uint64
+		expectRemaining []*bstream.OneBlockFile
+	}{
+		{
+			// block 300 == base(200)+size(100) after the first merge: it belongs to
+			// bundle 300, so bundle 200 must be skip-merged
+			name: "gap_ends_exactly_on_boundary",
+			gapBlocks: []*bstream.OneBlockFile{
+				obf("0000000300-0000000000000300a-0000000000000106a-106-suffix"),
+				obf("0000000301-0000000000000301a-0000000000000300a-300-suffix"),
+				obf("0000000302-0000000000000302a-0000000000000301a-301-suffix"),
+			},
+			expectMerged: []uint64{100, 200},
+			expectBase:   300,
+			expectRemaining: []*bstream.OneBlockFile{
+				block106Final104(),
+				obf("0000000300-0000000000000300a-0000000000000106a-106-suffix"),
+				obf("0000000301-0000000000000301a-0000000000000300a-300-suffix"),
+			},
+		},
+		{
+			name: "gap_ends_one_past_boundary",
+			gapBlocks: []*bstream.OneBlockFile{
+				obf("0000000301-0000000000000301a-0000000000000106a-106-suffix"),
+				obf("0000000302-0000000000000302a-0000000000000301a-301-suffix"),
+				obf("0000000303-0000000000000303a-0000000000000302a-302-suffix"),
+			},
+			expectMerged: []uint64{100, 200},
+			expectBase:   300,
+			expectRemaining: []*bstream.OneBlockFile{
+				block106Final104(),
+				obf("0000000301-0000000000000301a-0000000000000106a-106-suffix"),
+				obf("0000000302-0000000000000302a-0000000000000301a-301-suffix"),
+			},
+		},
+		{
+			// block 200 == base(100)+size(100): triggers the main merge only, no skip
+			name: "gap_ends_exactly_on_next_bundle_start",
+			gapBlocks: []*bstream.OneBlockFile{
+				obf("0000000200-0000000000000200a-0000000000000106a-106-suffix"),
+				obf("0000000201-0000000000000201a-0000000000000200a-200-suffix"),
+				obf("0000000202-0000000000000202a-0000000000000201a-201-suffix"),
+			},
+			expectMerged: []uint64{100},
+			expectBase:   200,
+			expectRemaining: []*bstream.OneBlockFile{
+				block106Final104(),
+				obf("0000000200-0000000000000200a-0000000000000106a-106-suffix"),
+				obf("0000000201-0000000000000201a-0000000000000200a-200-suffix"),
+			},
+		},
+	}
+
+	for _, c := range tests {
+		t.Run(c.name, func(t *testing.T) {
+			var merged []uint64
+			b := NewBundler(100, 700, 2, 100, &TestMergerIO{
+				MergeAndStoreFunc: func(_ context.Context, inclusiveLowerBlock uint64, _ []*bstream.OneBlockFile) error {
+					merged = append(merged, inclusiveLowerBlock)
+					return nil
+				},
+			}, 1, nil)
+			b.irreversibleBlocks = []*bstream.OneBlockFile{block100(), block101()}
+
+			for _, blk := range append(append([]*bstream.OneBlockFile{}, commonChain...), c.gapBlocks...) {
+				require.NoError(t, b.HandleBlockFile(blk))
+			}
+			b.WaitForMerges()
+
+			assert.Equal(t, c.expectMerged, merged)
+			assert.Equal(t, int(c.expectBase), int(b.baseBlockNum))
+			assert.Equal(t, c.expectRemaining, b.irreversibleBlocks)
+		})
+	}
+}

--- a/merger/bundler_test.go
+++ b/merger/bundler_test.go
@@ -2,6 +2,7 @@ package merger
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -295,5 +296,61 @@ func TestBundlerMergeKeepOne(t *testing.T) {
 			assert.Equal(t, c.expectRemaining, b.irreversibleBlocks)
 			assert.Equal(t, int(c.expectBase), int(b.baseBlockNum))
 		})
+	}
+}
+
+// testObjWrapper wraps a OneBlockFile the way the forkable does when it calls ProcessBlock.
+type testObjWrapper struct{ obf *bstream.OneBlockFile }
+
+func (w testObjWrapper) WrappedObject() any { return w.obf }
+
+func TestBundlerProcessBlockTerminatingReleasesLock(t *testing.T) {
+	// A merge failure marks the errgroup as stopped. When ProcessBlock is inside the
+	// skip-forward loop at that moment, it returns errTerminating: the bundler lock
+	// must not be left held, otherwise pruners calling getSafeBaseBlockNum deadlock.
+	started := make(chan struct{}, 1)
+	proceed := make(chan struct{})
+
+	b := NewBundler(100, 0, 2, 100, &TestMergerIO{
+		MergeAndStoreFunc: func(_ context.Context, _ uint64, _ []*bstream.OneBlockFile) error {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-proceed
+			return errors.New("merge failed")
+		},
+	}, 1, func(error) {})
+	b.enforceNextBlockOnBoundary = false
+	b.irreversibleBlocks = []*bstream.OneBlockFile{block100(), block101()}
+
+	done := make(chan error, 1)
+	go func() {
+		// block 1000 triggers the merge of bundle 100 (which blocks, then fails), then
+		// enters the skip-forward loop where eg.Stop() turns true once the merge has failed
+		done <- b.ProcessBlock(nil, testObjWrapper{obf: chainBlock(1000, 999, 999)})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first merge never started")
+	}
+	close(proceed) // let the merge fail, stopping the errgroup
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, errTerminating)
+	case <-time.After(5 * time.Second):
+		t.Fatal("ProcessBlock did not return")
+	}
+
+	// the bundler lock must be free after ProcessBlock returned errTerminating
+	got := make(chan uint64, 1)
+	go func() { got <- b.getSafeBaseBlockNum() }()
+	select {
+	case <-got:
+	case <-time.After(2 * time.Second):
+		t.Fatal("bundler lock leaked: getSafeBaseBlockNum deadlocked")
 	}
 }

--- a/merger/bundlereader.go
+++ b/merger/bundlereader.go
@@ -23,10 +23,14 @@ import (
 	"go.uber.org/zap"
 )
 
-// NewStreamingBundleReader creates an io.Reader that streams one-block-files directly from storage
+// NewStreamingBundleReader creates an io.ReadCloser that streams one-block-files directly from storage
 // without loading them into memory. It opens each file via opener one at a time, strips DBIN headers
 // from all files except the first, and pipes the concatenated output to the returned reader.
-func NewStreamingBundleReader(ctx context.Context, logger *zap.Logger, oneBlockFiles []*bstream.OneBlockFile, anyOneBlockFile *bstream.OneBlockFile, opener func(context.Context, *bstream.OneBlockFile) (io.ReadCloser, error)) (io.Reader, error) {
+//
+// The caller must Close the returned reader: if the consumer stops reading before EOF (e.g. a
+// store WriteObject timing out or erroring), closing unblocks the feeding goroutine so it can
+// release its open one-block reader and exit.
+func NewStreamingBundleReader(ctx context.Context, logger *zap.Logger, oneBlockFiles []*bstream.OneBlockFile, anyOneBlockFile *bstream.OneBlockFile, opener func(context.Context, *bstream.OneBlockFile) (io.ReadCloser, error)) (io.ReadCloser, error) {
 	// Open anyOneBlockFile just to determine the DBIN header length
 	headerReader, err := opener(ctx, anyOneBlockFile)
 	if err != nil {

--- a/merger/merger.go
+++ b/merger/merger.go
@@ -113,7 +113,11 @@ func (m *Merger) startForkedBlocksPruner() {
 	go func() {
 		delay := m.timeBetweenPruning // do not start pruning immediately
 		for {
-			time.Sleep(delay)
+			select {
+			case <-m.Terminating():
+				return
+			case <-time.After(delay):
+			}
 			now := time.Now()
 
 			pruningTarget := m.pruningTarget(m.pruningDistanceToLIB)
@@ -142,7 +146,11 @@ func (m *Merger) startOldFilesPruner() {
 
 		ctx := context.Background()
 		for {
-			time.Sleep(delay)
+			select {
+			case <-m.Terminating():
+				return
+			case <-time.After(delay):
+			}
 
 			var toDelete []*bstream.OneBlockFile
 

--- a/merger/merger.go
+++ b/merger/merger.go
@@ -250,7 +250,6 @@ func (m *Merger) run() error {
 			m.logger.Info("stop block reached")
 			return nil
 		default:
-			consecutiveErrors = 0
 			consecutiveErrors++
 			if consecutiveErrors >= 10 {
 				return fmt.Errorf("too many consecutive errors: %w", err)

--- a/merger/merger_io.go
+++ b/merger/merger_io.go
@@ -139,10 +139,14 @@ func (s *DStoreIO) MergeAndStore(ctx context.Context, inclusiveLowerBlock uint64
 	err = Retry(s.logger, s.retryAttempts, s.retryCooldown, func() error {
 		inCtx, cancel := context.WithTimeout(ctx, WriteObjectTimeout)
 		defer cancel()
-		streamReader, err := NewStreamingBundleReader(ctx, s.logger, filteredOBF, anyOneBlockFile, s.OpenOneBlockFile)
+		streamReader, err := NewStreamingBundleReader(inCtx, s.logger, filteredOBF, anyOneBlockFile, s.OpenOneBlockFile)
 		if err != nil {
 			return err
 		}
+		// If WriteObject returns without draining the reader (timeout or error), the
+		// feeding goroutine would block forever on the pipe, holding an open one-block
+		// reader on every retry. Closing the read end unblocks it so it can exit.
+		defer streamReader.Close()
 		return s.mergedBlocksStore.WriteObject(inCtx, bundleFilename, streamReader)
 	})
 	if err != nil {

--- a/merger/merger_io_test.go
+++ b/merger/merger_io_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"testing"
+	"time"
 
 	"google.golang.org/protobuf/types/known/anypb"
 
@@ -188,4 +189,59 @@ func TestMergerIO_MergeUploadFilteredToZero(t *testing.T) {
 	mio := newTestDStoreIO(oneBlockStore, dstore.NewMockStore(nil))
 	err := mio.MergeAndStore(context.Background(), 114, files)
 	require.NoError(t, err)
+}
+
+// notifyingReadCloser reports on a channel when it gets closed.
+type notifyingReadCloser struct {
+	io.ReadCloser
+	name   string
+	closed chan<- string
+}
+
+func (rc *notifyingReadCloser) Close() error {
+	rc.closed <- rc.name
+	return rc.ReadCloser.Close()
+}
+
+// TestMergerIO_WriteObjectErrorClosesStreamReader verifies that when WriteObject fails
+// without draining the streaming bundle reader, MergeAndStore closes the pipe so the
+// feeding goroutine exits and releases its open one-block reader instead of blocking
+// forever in io.Copy (leaking a goroutine and a reader on every retry).
+func TestMergerIO_WriteObjectErrorClosesStreamReader(t *testing.T) {
+	files := []*bstream.OneBlockFile{block100(), block101()}
+
+	// determine the DBIN header length so WriteObject can consume just past it,
+	// guaranteeing the feeding goroutine is inside io.Copy of block100 when we fail
+	hdrReader, err := bstream.NewDBinBlockReader(makeBlockReader(t))
+	require.NoError(t, err)
+	headerLen := len(hdrReader.Header.RawBytes)
+
+	closed := make(chan string, 10)
+	oneBlockStore := dstore.NewMockStore(nil)
+	oneBlockStore.OpenObjectFunc = func(_ context.Context, name string) (io.ReadCloser, error) {
+		return &notifyingReadCloser{ReadCloser: makeBlockReader(t), name: name, closed: closed}, nil
+	}
+
+	mergedBlocksStore := dstore.NewMockStore(func(base string, f io.Reader) error {
+		// read the bundle header plus one byte, then fail without draining the stream
+		if _, err := io.ReadFull(f, make([]byte, headerLen+1)); err != nil {
+			return err
+		}
+		return fmt.Errorf("write refused")
+	})
+
+	mio := newTestDStoreIO(oneBlockStore, mergedBlocksStore)
+	err = mio.MergeAndStore(context.Background(), 100, files)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "write refused")
+
+	// two closes expected: the synchronous header read, and the block100 streaming
+	// reader that the feeding goroutine must release once the pipe is closed
+	for i := 0; i < 2; i++ {
+		select {
+		case <-closed:
+		case <-time.After(3 * time.Second):
+			t.Fatal("feeding goroutine leaked: one-block reader never closed after WriteObject error")
+		}
+	}
 }

--- a/merger/merger_run_test.go
+++ b/merger/merger_run_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -389,4 +390,57 @@ func TestMergerRun_ConsecutiveWalkErrorsTriggerShutdown(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("merger did not shut down on persistent walk errors")
 	}
+}
+
+// forkAwareTestIO adds ForkAwareIOInterface on top of TestMergerIO so the
+// forked-blocks pruner can be exercised in tests.
+type forkAwareTestIO struct {
+	*TestMergerIO
+	deleteForkedCalls *atomic.Int64
+}
+
+func (f *forkAwareTestIO) DeleteForkedBlocksAsync(_, _ uint64) { f.deleteForkedCalls.Add(1) }
+func (f *forkAwareTestIO) MoveForkedBlocks(_ context.Context, _ []*bstream.OneBlockFile) {}
+
+// TestPrunersStopOnShutdown verifies that both pruner goroutines observe
+// merger termination and stop deleting files after Shutdown.
+func TestPrunersStopOnShutdown(t *testing.T) {
+	var walkCalls, deleteForkedCalls atomic.Int64
+
+	testIO := &forkAwareTestIO{
+		TestMergerIO: &TestMergerIO{
+			WalkOneBlockFilesFunc: func(_ context.Context, _ uint64, _ func(*bstream.OneBlockFile) error) error {
+				walkCalls.Add(1)
+				return nil
+			},
+		},
+		deleteForkedCalls: &deleteForkedCalls,
+	}
+
+	m := &Merger{
+		Shutter:                    shutter.New(),
+		io:                         testIO,
+		logger:                     testLogger,
+		timeBetweenPruning:         time.Millisecond,
+		pruningDistanceToLIB:       100,
+		oneBlockFilesPruneDistance: 100,
+		firstStreamableBlock:       2,
+	}
+	// bundler base 1000 makes the pruning target non-zero (1000 - 100 = 900)
+	m.bundler = NewBundler(1000, 0, 2, 100, testIO, 1, m.Shutdown)
+
+	m.startOldFilesPruner()
+	m.startForkedBlocksPruner()
+
+	require.Eventually(t, func() bool {
+		return walkCalls.Load() >= 1 && deleteForkedCalls.Load() >= 1
+	}, 2*time.Second, time.Millisecond, "pruners never ran")
+
+	m.Shutdown(nil)
+
+	time.Sleep(20 * time.Millisecond) // let any in-flight iteration finish
+	walksAfter, deletesAfter := walkCalls.Load(), deleteForkedCalls.Load()
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, walksAfter, walkCalls.Load(), "old-files pruner kept running after shutdown")
+	assert.Equal(t, deletesAfter, deleteForkedCalls.Load(), "forked-blocks pruner kept running after shutdown")
 }

--- a/merger/merger_run_test.go
+++ b/merger/merger_run_test.go
@@ -363,3 +363,30 @@ func TestMergerRun_CheckAlreadyMergedAfterManyBlocks(t *testing.T) {
 	assert.Less(t, highestCheckedOneBlock, uint64(200), "highestCheckedOneBlock should be less than 200")
 
 }
+
+// TestMergerRun_ConsecutiveWalkErrorsTriggerShutdown verifies the circuit breaker:
+// a persistently failing WalkOneBlockFiles must make run() return
+// "too many consecutive errors" after 10 attempts instead of retrying forever.
+func TestMergerRun_ConsecutiveWalkErrorsTriggerShutdown(t *testing.T) {
+	walkCalls := 0
+	testIO := &TestMergerIO{
+		WalkOneBlockFilesFunc: func(_ context.Context, _ uint64, _ func(*bstream.OneBlockFile) error) error {
+			walkCalls++
+			return errors.New("persistent store failure")
+		},
+	}
+
+	merger := newRunTestMerger(testIO, 0, 10, 1)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- merger.run() }()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "too many consecutive errors")
+		assert.Equal(t, 10, walkCalls, "circuit breaker should trip after exactly 10 consecutive errors")
+	case <-time.After(5 * time.Second):
+		t.Fatal("merger did not shut down on persistent walk errors")
+	}
+}


### PR DESCRIPTION
## Fixes

- **Dead circuit breaker** (`merger/merger.go`): the error branch reset
  `consecutiveErrors` before incrementing it, so the `>= 10` shutdown threshold was
  unreachable and the merger retried forever on persistent store failure while
  healthz stayed SERVING. The reset now only happens on success.
- **Bundler lock leak** (`merger/bundler.go`): returning `errTerminating` from the
  skip-forward loop left the bundler mutex held, deadlocking pruners in
  `getSafeBaseBlockNum()`. The lock is now released via `defer`, and `eg.Stop()` is
  checked before marking a bundle in-flight so termination no longer leaves a stale
  in-flight entry.
- **Skip-loop off-by-one** (`merger/bundler.go`): a bundle covers
  `[base, base+size)`, so a post-gap block landing exactly on `base+size` belongs to
  the next bundle; the `>` condition attributed it to the previous one, producing a
  merged file whose only block is out of range plus a duplicate in the next bundle.
  Condition changed to `>=`.
- **Pipe reader leak** (`merger/merger_io.go`, `merger/bundlereader.go`): when
  `WriteObject` failed or timed out without draining the streaming bundle reader,
  the feeding goroutine blocked forever in `io.Copy` holding an open one-block
  reader, leaking per retry. The pipe reader is now closed on every attempt, and the
  reader runs under the per-attempt timeout ctx so its between-files check fires.
- **Pruners ignore shutdown** (`merger/merger.go`): both pruner goroutines looped on
  `time.Sleep` and kept deleting files during/after shutdown. They now select on
  `Terminating()` vs the timer.

## Tests

New regression tests, each verified to fail against the pre-fix code:

- `TestMergerRun_ConsecutiveWalkErrorsTriggerShutdown`
- `TestBundlerProcessBlockTerminatingReleasesLock`
- `TestBundlerSkipLoopBoundary` (table: exact boundary, one past, exact next-bundle start)
- `TestMergerIO_WriteObjectErrorClosesStreamReader`
- `TestPrunersStopOnShutdown`

`go test ./merger/...` passes. `go test -race ./merger/...` passes except the
pre-existing data race inside `TestMergerRun_FailedBundleCausesShutdown`'s own test
code (unsynchronized `err`/counter access), which fails identically on clean
`develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
