### PR TITLE
Bump substreams to latest develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 ## Unreleased
 
+### Changed
+
+- Bumped `substreams` to latest `develop`.
+  - Server: store quicksave/quickload now run up to 8 stores concurrently instead of one at a time, and quicksave streams the store lazily and unsorted (one KV entry at a time, no key sort/allocation) instead of buffering the whole serialized store, lowering peak memory and save time for large stores. On-disk format is unchanged; quickload is order-independent.
+  - Server: tier1 store loading at request start now loads up to 8 stores concurrently (size probe + download/decode) instead of one at a time.
+
 ### Added
 
 - merger: new `--merger-prune-one-block-files-after` flag (default `100`) controlling how many blocks below the last merged block one-block files are kept before deletion. Raise it so a relayer/firehose that briefly falls behind can still find the one-block files needed to bridge the gap and relink, instead of getting stuck in a reconnect loop or dying with `cannot link block after reconnection, restart required`. Clamped to a minimum of `100` (the bundle size) to preserve the safety margin against deleting not-yet-merged files.

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/streamingfast/payment-gateway v0.0.0-20260527144655-d0576d2a4ee3
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0
-	github.com/streamingfast/substreams v1.19.1-0.20260703191612-042ed978a2bc
+	github.com/streamingfast/substreams v1.19.1-0.20260706184107-5a35d25e98db
 	github.com/stretchr/testify v1.11.1
 	github.com/test-go/testify v1.1.4
 	github.com/testcontainers/testcontainers-go v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -2340,8 +2340,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.19.1-0.20260703191612-042ed978a2bc h1:fCVYq6wDws9LA7P2UmEQgQ094IrxM9CncvoTLSxcuRw=
-github.com/streamingfast/substreams v1.19.1-0.20260703191612-042ed978a2bc/go.mod h1:fQCdmwjeF+W2MhLEmFG1tEnsp85dwVv5vDgbaRcuzeQ=
+github.com/streamingfast/substreams v1.19.1-0.20260706184107-5a35d25e98db h1:NU1Y6CnxP/099SoZeaTFIcBI/fJWA5pamoJKpSVMn3Y=
+github.com/streamingfast/substreams v1.19.1-0.20260706184107-5a35d25e98db/go.mod h1:fQCdmwjeF+W2MhLEmFG1tEnsp85dwVv5vDgbaRcuzeQ=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=


### PR DESCRIPTION
Bumps `substreams` to latest `develop` (`5a35d25e`), picking up streamingfast/substreams#822:

- **Lazy + unsorted store quicksave** — serializes one KV entry at a time as the upload consumes it, without sorting keys, instead of buffering the whole serialized store and paying an O(n log n) key sort + key-slice allocation. Lowers peak memory and save time for large stores. On-disk format unchanged; quickload is order-independent.
- **Parallel quicksave/quickload** — up to 8 stores concurrently instead of one at a time.
- **Parallel tier1 store load** at request start (size probe + download/decode), up to 8 concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)