### PR TITLE
Skip secret-dependent CI steps for dependabot PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -105,7 +105,7 @@ jobs:
             VERSION=${{ steps.extract-version.outputs.VERSION }}
 
       - name: Docker Scout
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]' }}
         uses: docker/scout-action@v1
         with:
           dockerhub-user: ${{ secrets.DOCKER_SCOUT_USER }}
@@ -119,7 +119,7 @@ jobs:
 
       - name: Get Job ID from GH API
         id: get_job_id
-        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -128,7 +128,7 @@ jobs:
           echo "job_id=$job_id" >> $GITHUB_OUTPUT
 
       - name: Notify build failure on Slack
-        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         uses: Ilshidur/action-slack@2.1.0
@@ -138,7 +138,7 @@ jobs:
 
   push:
     needs: [setup, docker-build]
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-24.04
 
     outputs:

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Secret Scanning Review
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         uses: advanced-security/secret-scanning-review-action@v2.2.4
         with:
           token: ${{ secrets.SECRETS_ALERTS }}


### PR DESCRIPTION
## Problem

`check-secrets` and `docker-build (amd64/arm64)` are required checks but fail on **every** dependabot PR. Dependabot runs workflows with a restricted token where `secrets.*` resolve to empty:

- `secret-scanning.yml` → `secrets.SECRETS_ALERTS` empty → `401 Unauthorized`
- `docker.yml` Docker Scout → `secrets.DOCKER_SCOUT_*` / `PR_COMMENTER` empty → `Parameter token or opts.auth is required` (then the `failure()` Slack step also dies on empty `SLACK_WEBHOOK`)

These steps were already skipped for **fork** PRs via `head.repo.full_name == github.repository`, but dependabot branches live in this repo, so that guard passes and the steps run without secrets.

Same root cause and fix as streamingfast/substreams#845.

## Fix

Extend the existing fork guard to also exclude the `dependabot[bot]` actor:

- `check-secrets` step skips → job green.
- Docker Scout + the `failure()` Slack-notify steps skip → `docker-build` builds the image (still validates the Dockerfile) → job green.
- `push` job (and its dependent `slack-notifications`) also excluded, so they keep skipping once `docker-build` goes green instead of newly running against a read-only token.

Full secret-scanning and Scout coverage still runs on push to `develop`.

Result: dependabot PRs go green on required checks without an admin bypass.