### PR TITLE
relayer: seed head_block_number metric from hub head on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 - `tools print merged-blocks <store>` no longer truncates its output when a merged-blocks file is missing (open range with no explicit stop, or a bounded range extending past the last available file): with the bumped `bstream` dependency it now prints every available block first, instead of discarding in-flight files on an async shutdown. On an open range it caps the stream at the last available merged-blocks file (found with an `O(log n)` existence probe rather than a full store listing) so it stops cleanly instead of erroring on the expected-missing next file. Also fixes an off-by-one that stopped one block early on a closed range, and a potential unsigned underflow when a closed range ends at block 0.
 - Merger: fixed a lock leak, a dead consecutive-errors circuit breaker, a skip-loop boundary off-by-one, a streaming bundle-reader goroutine leak, and pruners that ignored shutdown.
-- Relayer: the `head_block_number` metric is now seeded from the hub's head once it is ready (bootstrapped from one-block files), instead of only after a live block flows through. On chains that produce blocks on demand, the metric no longer stays absent after a restart until the next block is mined.
+- Relayer: the head metrics (`head_block_number`, `head_block_time_drift`, `head_block_relative_time`) are now seeded from the hub's head once it is ready (bootstrapped from one-block files), instead of only after a live block flows through. On chains that produce blocks on demand, these metrics no longer stay absent after a restart until the next block is mined.
 
 ## v1.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 - `tools print merged-blocks <store>` no longer truncates its output when a merged-blocks file is missing (open range with no explicit stop, or a bounded range extending past the last available file): with the bumped `bstream` dependency it now prints every available block first, instead of discarding in-flight files on an async shutdown. On an open range it caps the stream at the last available merged-blocks file (found with an `O(log n)` existence probe rather than a full store listing) so it stops cleanly instead of erroring on the expected-missing next file. Also fixes an off-by-one that stopped one block early on a closed range, and a potential unsigned underflow when a closed range ends at block 0.
 - Merger: fixed a lock leak, a dead consecutive-errors circuit breaker, a skip-loop boundary off-by-one, a streaming bundle-reader goroutine leak, and pruners that ignored shutdown.
+- Relayer: the `head_block_number` metric is now seeded from the hub's head once it is ready (bootstrapped from one-block files), instead of only after a live block flows through. On chains that produce blocks on demand, the metric no longer stays absent after a restart until the next block is mined.
 
 ## v1.15.0
 

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -144,9 +144,17 @@ func (r *Relayer) Run() {
 	zlog.Info("waiting for hub to be ready...")
 	<-r.hub.Ready
 
-	// Set head_block_number so we know the head immediately
-	if headNum := r.hub.HeadNum(); headNum != 0 {
+	// Seed head metrics from the bootstrapped hub head so we report it
+	// immediately, instead of only once a live block flows through the forkable.
+	if headNum, headID, headTime, _, err := r.hub.HeadInfo(); err == nil {
+		zlog.Info("seeding head metrics from hub head",
+			zap.Uint64("head_num", headNum),
+			zap.String("head_id", headID),
+			zap.Time("head_time", headTime),
+		)
 		metrics.HeadBlockNumber.SetUint64(headNum)
+		metrics.HeadBlockTimeDrift.SetBlockTime(headTime)
+		metrics.HeadBlockRelativeDrift.SetLastBlock(headTime)
 	}
 
 	r.OnTerminating(func(e error) {

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -144,6 +144,11 @@ func (r *Relayer) Run() {
 	zlog.Info("waiting for hub to be ready...")
 	<-r.hub.Ready
 
+	// Set head_block_number so we know the head immediately
+	if headNum := r.hub.HeadNum(); headNum != 0 {
+		metrics.HeadBlockNumber.SetUint64(headNum)
+	}
+
 	r.OnTerminating(func(e error) {
 		zlog.Info("closing block stream server")
 		r.blockStreamServer.Close()


### PR DESCRIPTION
## Problem

The relayer's `head_block_number` Prometheus gauge is a labeled gauge (`GaugeVec` keyed by `app`), so the `head_block_number{app="relayer"}` series only appears in `/metrics` after `.Set()` is called at least once. That call only happens when a **live** block flows through the forkable:

- `relayer.go` wires `forkable.WithMetrics(metrics.HeadBlockNumber, ...)`.
- The gauge is written only `if p.liveMetrics` (forkable), and `liveMetrics` is flipped only in `hub.ProcessBlock` (`SetLiveMetrics()`), which runs only when a live block arrives.

On chains that **mine blocks on demand**, no new block may arrive after a relayer restart, so the series is never created and scrapers can't see it — even though the hub already knows its head from bootstrapping the one-block files (`hub.bootstrap()` populates the forkable and closes `Ready`, but does not touch `liveMetrics`).

## Fix

Seed `metrics.HeadBlockNumber` from `r.hub.HeadNum()` immediately after the hub becomes ready, so consumers can read the known head right away instead of waiting for the next mined block. It stays static until a live block arrives, which is correct for an idle on-demand chain.

Note: this only helps when the hub bootstrapped from one-block files (the common restart case). If the one-blocks store is empty, the relayer is genuinely not-ready and has no head to report until its first live block — unchanged by this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
