### PR TITLE
Add finalized_block_number metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Operators, you should copy/paste content of this content straight to your projec
 
 If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you should copy the content between those 2 version to your own repository, replacing placeholder value `fire{chain}` with your chain's own binary.
 
+## Unreleased
+
+### Added
+
+- New `finalized_block_number{app}` metric, reported by `reader-node`, `reader-node-stdin`, `reader-node-firehose`, `relayer`, `firehose`, `merger` and `block-indexer`. Paired with the existing `head_block_number{app}`, it lets dashboards show how far behind finality each app's head is, as `head_block_number - finalized_block_number`. The `merger` and `block-indexer` only ever process final blocks, so they report the same value for both.
+
+### Changed
+
+- Bumped `bstream` for `forkable.WithFinalizedBlockNumMetric`, the option backing the new `finalized_block_number` metric on the `relayer`.
+
 ## v1.16.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 - Bumped `bstream` for `forkable.WithFinalizedBlockNumMetric`, the option backing the new `finalized_block_number` metric on the `relayer`.
 
+### Security
+
+- Bumped `google.golang.org/grpc` to `v1.82.1`, fixing GHSA-hrxh-6v49-42gf (HIGH, CVSS 8.8), an uncaught exception reachable from the network.
+
 ## v1.16.0
 
 ### Added

--- a/cmd/apps/firehose.go
+++ b/cmd/apps/firehose.go
@@ -17,6 +17,7 @@ import (
 	"github.com/streamingfast/firehose-core/firehose/app/firehose"
 	"github.com/streamingfast/firehose-core/firehose/server"
 	"github.com/streamingfast/firehose-core/launcher"
+	coremetrics "github.com/streamingfast/firehose-core/metrics"
 	"github.com/streamingfast/logging"
 	"go.uber.org/zap"
 )
@@ -24,6 +25,7 @@ import (
 var metricset = dmetrics.NewSet()
 var headBlockNumMetric = metricset.NewHeadBlockNumber("firehose")
 var headTimeDriftmetric = metricset.NewHeadTimeDrift("firehose")
+var finalizedBlockNumMetric = coremetrics.NewFinalizedBlockNumber("firehose")
 
 func RegisterFirehoseApp[B firecore.Block](chain *firecore.Chain[B], rootLog *zap.Logger) {
 	appLogger, appTracer := logging.PackageLogger("firehose", "firehose")
@@ -114,13 +116,14 @@ func RegisterFirehoseApp[B firecore.Block](chain *firecore.Chain[B], rootLog *za
 				ServiceDiscoveryURL:     serviceDiscoveryURL,
 				ServerOptions:           serverOptions,
 			}, &firehose.Modules{
-				Authenticator:         authenticator,
-				SessionPool:           sessionPool,
-				HeadTimeDriftMetric:   headTimeDriftmetric,
-				HeadBlockNumberMetric: headBlockNumMetric,
-				TransformRegistry:     registry,
-				CheckPendingShutdown:  runtime.IsPendingShutdown,
-				InfoServer:            runtime.InfoServer,
+				Authenticator:              authenticator,
+				SessionPool:                sessionPool,
+				HeadTimeDriftMetric:        headTimeDriftmetric,
+				HeadBlockNumberMetric:      headBlockNumMetric,
+				FinalizedBlockNumberMetric: finalizedBlockNumMetric,
+				TransformRegistry:          registry,
+				CheckPendingShutdown:       runtime.IsPendingShutdown,
+				InfoServer:                 runtime.InfoServer,
 			}), nil
 		},
 	})

--- a/cmd/apps/reader_node.go
+++ b/cmd/apps/reader_node.go
@@ -15,6 +15,7 @@ import (
 	"github.com/streamingfast/cli"
 	firecore "github.com/streamingfast/firehose-core"
 	"github.com/streamingfast/firehose-core/launcher"
+	coremetrics "github.com/streamingfast/firehose-core/metrics"
 	nodeManager "github.com/streamingfast/firehose-core/node-manager"
 	nodeManagerApp "github.com/streamingfast/firehose-core/node-manager/app/node_manager"
 	"github.com/streamingfast/firehose-core/node-manager/metrics"
@@ -160,6 +161,7 @@ func RegisterReaderNodeApp[B firecore.Block](chain *firecore.Chain[B], rootLog *
 			headBlockTimeDrift := metrics.NewHeadBlockTimeDrift("reader-node")
 			headBlockNumber := metrics.NewHeadBlockNumber("reader-node")
 			headBlockRelativeTime := metrics.NewHeadBlockRelativeTime("reader-node")
+			finalizedBlockNumber := coremetrics.NewFinalizedBlockNumber("reader-node")
 			appReadiness := metrics.NewAppReadiness("reader-node")
 
 			metricsAndReadinessManager := nodeManager.NewMetricsAndReadinessManager(
@@ -168,6 +170,7 @@ func RegisterReaderNodeApp[B firecore.Block](chain *firecore.Chain[B], rootLog *
 				headBlockRelativeTime,
 				appReadiness,
 				readinessMaxLatency,
+				nodeManager.WithFinalizedBlockNumberMetric(finalizedBlockNumber),
 			)
 
 			lineBufferSize := viper.GetUint64("reader-node-line-buffer-size")

--- a/cmd/apps/reader_node_stdin.go
+++ b/cmd/apps/reader_node_stdin.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/viper"
 	firecore "github.com/streamingfast/firehose-core"
 	"github.com/streamingfast/firehose-core/launcher"
+	coremetrics "github.com/streamingfast/firehose-core/metrics"
 	nodeManager "github.com/streamingfast/firehose-core/node-manager"
 	nodeReaderStdinApp "github.com/streamingfast/firehose-core/node-manager/app/node_reader_stdin"
 	"github.com/streamingfast/firehose-core/node-manager/metrics"
@@ -62,8 +63,9 @@ func RegisterReaderNodeStdinApp[B firecore.Block](chain *firecore.Chain[B], root
 			headBlockTimeDrift := metrics.NewHeadBlockTimeDrift(metricID)
 			headBlockNumber := metrics.NewHeadBlockNumber(metricID)
 			headBlockRelativeTime := metrics.NewHeadBlockRelativeTime(metricID)
+			finalizedBlockNumber := coremetrics.NewFinalizedBlockNumber(metricID)
 			appReadiness := metrics.NewAppReadiness(metricID)
-			metricsAndReadinessManager := nodeManager.NewMetricsAndReadinessManager(headBlockTimeDrift, headBlockNumber, headBlockRelativeTime, appReadiness, viper.GetDuration("reader-node-readiness-max-latency"))
+			metricsAndReadinessManager := nodeManager.NewMetricsAndReadinessManager(headBlockTimeDrift, headBlockNumber, headBlockRelativeTime, appReadiness, viper.GetDuration("reader-node-readiness-max-latency"), nodeManager.WithFinalizedBlockNumberMetric(finalizedBlockNumber))
 
 			return nodeReaderStdinApp.New(&nodeReaderStdinApp.Config{
 				GRPCAddr:                   viper.GetString("reader-node-grpc-listen-addr"),

--- a/firehose/app/firehose/app.go
+++ b/firehose/app/firehose/app.go
@@ -34,6 +34,7 @@ import (
 	"github.com/streamingfast/firehose-core/firehose/info"
 	"github.com/streamingfast/firehose-core/firehose/metrics"
 	"github.com/streamingfast/firehose-core/firehose/server"
+	coremetrics "github.com/streamingfast/firehose-core/metrics"
 	"github.com/streamingfast/logging"
 	"github.com/streamingfast/shutter"
 	"go.uber.org/atomic"
@@ -61,6 +62,9 @@ type Modules struct {
 	TransformRegistry     *transform.Registry
 	CheckPendingShutdown  func() bool
 	InfoServer            *info.InfoServer
+
+	// Optional dependencies
+	FinalizedBlockNumberMetric *coremetrics.FinalizedBlockNum
 }
 
 type App struct {
@@ -133,6 +137,9 @@ func (a *App) Run() error {
 					}
 					a.modules.HeadBlockNumberMetric.SetUint64(blk.Number)
 					a.modules.HeadTimeDriftMetric.SetBlockTime(blk.Time())
+					if a.modules.FinalizedBlockNumberMetric != nil {
+						a.modules.FinalizedBlockNumberMetric.SetUint64(blk.LibNum)
+					}
 					return h.ProcessBlock(blk, obj)
 				}),
 				blockstream.WithRequester("firehose"),

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6
-	google.golang.org/grpc v1.82.0
+	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 )
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
-	github.com/streamingfast/bstream v0.0.2-0.20260709191130-aecaf73e1c32
+	github.com/streamingfast/bstream v0.0.2-0.20260722130256-743b153b4fa9
 	github.com/streamingfast/cli v0.0.4-0.20250815192146-d8a233ec3d0b
 	github.com/streamingfast/dauth v0.0.0-20260318230957-4ab1e1d2ebc3
 	github.com/streamingfast/derr v0.0.0-20250814163534-bd7407bd89d7

--- a/go.sum
+++ b/go.sum
@@ -3281,6 +3281,8 @@ google.golang.org/grpc v1.63.2/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDom
 google.golang.org/grpc v1.64.0/go.mod h1:oxjF8E3FBnjp+/gVFYdWacaLDx9na1aqy9oovLpxQYg=
 google.golang.org/grpc v1.82.0 h1:vguDnZUPjE26w09A63VoxZPnvPjB5Riyc0mkXPFmAIU=
 google.golang.org/grpc v1.82.0/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/go.sum
+++ b/go.sum
@@ -2283,6 +2283,10 @@ github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xI
 github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/streamingfast/bstream v0.0.2-0.20260709191130-aecaf73e1c32 h1:lXdt7nh4oP3+x+uf+E/R3GkZ1gvUOldFIJLMMxhjupk=
 github.com/streamingfast/bstream v0.0.2-0.20260709191130-aecaf73e1c32/go.mod h1:Asuul2Rnxln0Vk6eY869AZ2UybIQcB7eYOQAIhfQHzE=
+github.com/streamingfast/bstream v0.0.2-0.20260721235130-d566a9ffae22 h1:5L3oI2FFjSdB29NKZnb2FivYWkdBnNesjBMunP8pN34=
+github.com/streamingfast/bstream v0.0.2-0.20260721235130-d566a9ffae22/go.mod h1:Asuul2Rnxln0Vk6eY869AZ2UybIQcB7eYOQAIhfQHzE=
+github.com/streamingfast/bstream v0.0.2-0.20260722130256-743b153b4fa9 h1:h4wlxecft/9fF+gzYR73m7HAEa9vMzRyfTdY91D7l9M=
+github.com/streamingfast/bstream v0.0.2-0.20260722130256-743b153b4fa9/go.mod h1:Asuul2Rnxln0Vk6eY869AZ2UybIQcB7eYOQAIhfQHzE=
 github.com/streamingfast/cli v0.0.4-0.20250815192146-d8a233ec3d0b h1:ztYeX3/5rg2tV2EU7edcrcHzMz6wUbdJB+LqCrP5W8s=
 github.com/streamingfast/cli v0.0.4-0.20250815192146-d8a233ec3d0b/go.mod h1:o9R/tjNON01X2mgWL5qirl2MV6xQ4EZI5D504ST3K/M=
 github.com/streamingfast/dauth v0.0.0-20260318230957-4ab1e1d2ebc3 h1:Zo2daSGDUPoK32w9G1e9fZO3Q6b5Cvu5ZojdoD/Wgp8=

--- a/index-builder/index-builder.go
+++ b/index-builder/index-builder.go
@@ -73,6 +73,7 @@ func (app *IndexBuilder) launch() error {
 		app.logger.Debug("handling block", zap.Uint64("block_num", block.Number))
 
 		metrics.HeadBlockNumber.SetUint64(block.Number)
+		metrics.FinalizedBlockNumber.SetUint64(block.Number)
 		metrics.HeadBlockTimeDrift.SetBlockTime(block.Time())
 		metrics.AppReadiness.SetReady()
 

--- a/index-builder/metrics/metrics.go
+++ b/index-builder/metrics/metrics.go
@@ -1,9 +1,18 @@
 package metrics
 
-import "github.com/streamingfast/dmetrics"
+import (
+	"github.com/streamingfast/dmetrics"
+	coremetrics "github.com/streamingfast/firehose-core/metrics"
+)
 
 var MetricSet = dmetrics.NewSet()
 
 var HeadBlockTimeDrift = MetricSet.NewHeadTimeDrift("block-indexer")
 var HeadBlockNumber = MetricSet.NewHeadBlockNumber("block-indexer")
+
+// FinalizedBlockNumber always tracks HeadBlockNumber: the index builder streams with
+// `FinalBlocksOnly`, so its head is finalized by construction. Reporting the LIB number
+// carried by those blocks would trail our own head and read as if the index builder
+// were lagging finality.
+var FinalizedBlockNumber = coremetrics.NewFinalizedBlockNumber("block-indexer")
 var AppReadiness = MetricSet.NewAppReadiness("block-indexer")

--- a/merger/bundler.go
+++ b/merger/bundler.go
@@ -216,6 +216,9 @@ func (b *Bundler) ProcessBlock(_ *pbbstream.Block, obj interface{}) error {
 		metrics.AppReadiness.SetReady()
 		b.irreversibleBlocks = append(b.irreversibleBlocks, obf)
 		metrics.HeadBlockNumber.SetUint64(obf.Num)
+		// The merger only ever bundles irreversible blocks, so its head block is a
+		// finalized block, hence both metrics reporting the same value.
+		metrics.FinalizedBlockNumber.SetUint64(obf.Num)
 		b.Unlock()
 		if time.Since(time.Unix(0, b.blockTimestampLastRun.Load())) >= time.Second*5 && b.blockTimestampInFlight.CompareAndSwap(false, true) {
 			b.blockTimestampLastRun.Store(time.Now().UnixNano())

--- a/merger/merger_io.go
+++ b/merger/merger_io.go
@@ -208,6 +208,9 @@ func (s *DStoreIO) NextBundle(ctx context.Context, lowestBaseBlock uint64) (outB
 		}
 		metrics.HeadBlockTimeDrift.SetBlockTime(*lastTime)
 		metrics.HeadBlockNumber.SetUint64(last.Num())
+		// The merger only ever bundles irreversible blocks, so its head block is a
+		// finalized block, hence both metrics reporting the same value.
+		metrics.FinalizedBlockNumber.SetUint64(last.Num())
 		lib = last
 	}
 

--- a/merger/metrics/metrics.go
+++ b/merger/metrics/metrics.go
@@ -14,10 +14,19 @@
 
 package metrics
 
-import "github.com/streamingfast/dmetrics"
+import (
+	"github.com/streamingfast/dmetrics"
+	coremetrics "github.com/streamingfast/firehose-core/metrics"
+)
 
 var MetricSet = dmetrics.NewSet()
 
 var HeadBlockTimeDrift = MetricSet.NewHeadTimeDrift("merger")
 var HeadBlockNumber = MetricSet.NewHeadBlockNumber("merger")
+
+// FinalizedBlockNumber always tracks HeadBlockNumber: the merger only ever bundles
+// irreversible blocks, so its head is finalized by construction. Reporting the LIB
+// number carried by those blocks would trail our own head and read as if the merger
+// were lagging finality.
+var FinalizedBlockNumber = coremetrics.NewFinalizedBlockNumber("merger")
 var AppReadiness = MetricSet.NewAppReadiness("merger")

--- a/metrics/finalized_block.go
+++ b/metrics/finalized_block.go
@@ -1,0 +1,48 @@
+// Package metrics holds metrics that are shared by more than one Firehose app.
+//
+// Metrics defined here follow the `dmetrics` convention of a single package-level
+// collector labelled by `app`, registered once at init time. Per-app instances are
+// thin wrappers holding only the label value, which is what makes them safe when
+// multiple apps run within the same process.
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/streamingfast/dmetrics"
+)
+
+var finalizedBlockNumber = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "finalized_block_number",
+	Help: "Block number of the last known finalized (irreversible) block",
+}, []string{"app"})
+
+// FinalizedBlockNum reports the last known finalized (irreversible) block number for a
+// given app. Paired with `head_block_number`, it tells how far behind finality the head
+// of that app is.
+type FinalizedBlockNum struct {
+	app string
+}
+
+var _ prometheus.Collector = (*FinalizedBlockNum)(nil)
+
+func NewFinalizedBlockNumber(app string) *FinalizedBlockNum {
+	return &FinalizedBlockNum{app: app}
+}
+
+func (f *FinalizedBlockNum) SetUint64(blockNum uint64) {
+	finalizedBlockNumber.WithLabelValues(f.app).Set(float64(blockNum))
+}
+
+// Collect implements prometheus.Collector.
+func (f *FinalizedBlockNum) Collect(ch chan<- prometheus.Metric) {
+	finalizedBlockNumber.Collect(ch)
+}
+
+// Describe implements prometheus.Collector.
+func (f *FinalizedBlockNum) Describe(ch chan<- *prometheus.Desc) {
+	finalizedBlockNumber.Describe(ch)
+}
+
+func init() {
+	dmetrics.PrometheusRegister(finalizedBlockNumber)
+}

--- a/metrics/finalized_block_test.go
+++ b/metrics/finalized_block_test.go
@@ -1,0 +1,35 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFinalizedBlockNumberPerApp(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(NewFinalizedBlockNumber("relayer")))
+
+	NewFinalizedBlockNumber("relayer").SetUint64(100)
+	NewFinalizedBlockNumber("merger").SetUint64(90)
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	require.Len(t, mfs, 1)
+	assert.Equal(t, "finalized_block_number", mfs[0].GetName())
+
+	values := make(map[string]float64)
+	for _, m := range mfs[0].GetMetric() {
+		var app string
+		for _, lp := range m.GetLabel() {
+			if lp.GetName() == "app" {
+				app = lp.GetValue()
+			}
+		}
+		values[app] = m.GetGauge().GetValue()
+	}
+
+	assert.Equal(t, map[string]float64{"relayer": 100, "merger": 90}, values)
+}

--- a/node-manager/app/firehose_reader/metrics.go
+++ b/node-manager/app/firehose_reader/metrics.go
@@ -1,6 +1,9 @@
 package firehose_reader
 
-import "github.com/streamingfast/dmetrics"
+import (
+	"github.com/streamingfast/dmetrics"
+	coremetrics "github.com/streamingfast/firehose-core/metrics"
+)
 
 var metrics = dmetrics.NewSet(dmetrics.PrefixNameWith("reader_node_firehose"))
 
@@ -15,3 +18,4 @@ var HeadBlockTimeDrift = metrics.NewHeadTimeDrift(HeadDriftServiceName)
 var HeadBlockRelativeTime = metrics.NewHeadBlockRelativeTime(HeadDriftServiceName)
 var HeadBlockNumber = metrics.NewHeadBlockNumber(HeadDriftServiceName)
 var AppReadiness = metrics.NewAppReadiness(HeadDriftServiceName)
+var FinalizedBlockNumber = coremetrics.NewFinalizedBlockNumber(HeadDriftServiceName)

--- a/node-manager/app/firehose_reader/syncer.go
+++ b/node-manager/app/firehose_reader/syncer.go
@@ -95,7 +95,7 @@ func (s *syncer) Run() error {
 		s.logger.Info("no state file found, starting from block num", zap.Uint64("start_block_num", s.config.StartBlockNum))
 	}
 
-	metricsManager := nodeManager.NewMetricsAndReadinessManager(HeadBlockTimeDrift, HeadBlockNumber, HeadBlockRelativeTime, AppReadiness, s.config.ReadinessMaxLatency)
+	metricsManager := nodeManager.NewMetricsAndReadinessManager(HeadBlockTimeDrift, HeadBlockNumber, HeadBlockRelativeTime, AppReadiness, s.config.ReadinessMaxLatency, nodeManager.WithFinalizedBlockNumberMetric(FinalizedBlockNumber))
 	go metricsManager.Launch()
 
 	stats := newSyncerStats(metricsManager)

--- a/node-manager/monitor.go
+++ b/node-manager/monitor.go
@@ -9,6 +9,7 @@ import (
 	pbbstream "github.com/streamingfast/bstream/pb/sf/bstream/v1"
 
 	"github.com/streamingfast/dmetrics"
+	coremetrics "github.com/streamingfast/firehose-core/metrics"
 	"go.uber.org/atomic"
 )
 
@@ -34,6 +35,7 @@ type MetricsAndReadinessManager struct {
 	headBlockTimeDrift     *dmetrics.HeadTimeDrift
 	headBlockNumber        *dmetrics.HeadBlockNum
 	headBlockRelativeDrift *dmetrics.HeadBlockRelativeTime
+	finalizedBlockNumber   *coremetrics.FinalizedBlockNum
 	appReadiness           *dmetrics.AppReadiness
 	readinessProbe         *atomic.Bool
 
@@ -44,8 +46,20 @@ type MetricsAndReadinessManager struct {
 	lastSeenBlock *atomic.Pointer[pbbstream.Block]
 }
 
-func NewMetricsAndReadinessManager(headBlockTimeDrift *dmetrics.HeadTimeDrift, headBlockNumber *dmetrics.HeadBlockNum, headBlockRelativeDrift *dmetrics.HeadBlockRelativeTime, appReadiness *dmetrics.AppReadiness, readinessMaxLatency time.Duration) *MetricsAndReadinessManager {
-	return &MetricsAndReadinessManager{
+// MetricsAndReadinessOption customizes a MetricsAndReadinessManager. It exists so that new
+// metrics can be added without breaking chain repositories calling NewMetricsAndReadinessManager.
+type MetricsAndReadinessOption func(*MetricsAndReadinessManager)
+
+// WithFinalizedBlockNumberMetric reports the LIB number of each head block seen, so that
+// head to finality drift can be computed from `head_block_number - finalized_block_number`.
+func WithFinalizedBlockNumberMetric(finalizedBlockNumber *coremetrics.FinalizedBlockNum) MetricsAndReadinessOption {
+	return func(m *MetricsAndReadinessManager) {
+		m.finalizedBlockNumber = finalizedBlockNumber
+	}
+}
+
+func NewMetricsAndReadinessManager(headBlockTimeDrift *dmetrics.HeadTimeDrift, headBlockNumber *dmetrics.HeadBlockNum, headBlockRelativeDrift *dmetrics.HeadBlockRelativeTime, appReadiness *dmetrics.AppReadiness, readinessMaxLatency time.Duration, options ...MetricsAndReadinessOption) *MetricsAndReadinessManager {
+	manager := &MetricsAndReadinessManager{
 		headBlockChan:          make(chan *pbbstream.Block, 1), // just for non-blocking, saving a few nanoseconds here
 		readinessProbe:         atomic.NewBool(false),
 		appReadiness:           appReadiness,
@@ -56,6 +70,12 @@ func NewMetricsAndReadinessManager(headBlockTimeDrift *dmetrics.HeadTimeDrift, h
 
 		lastSeenBlock: atomic.NewPointer[pbbstream.Block](nil),
 	}
+
+	for _, option := range options {
+		option(manager)
+	}
+
+	return manager
 }
 
 func (m *MetricsAndReadinessManager) setReadinessProbeOn() {
@@ -82,6 +102,12 @@ func (m *MetricsAndReadinessManager) Launch() {
 			// metrics
 			if m.headBlockNumber != nil {
 				m.headBlockNumber.SetUint64(block.Number)
+			}
+
+			// Set before the zero timestamp check below, a block without a timestamp still
+			// carries a valid LIB number.
+			if m.finalizedBlockNumber != nil {
+				m.finalizedBlockNumber.SetUint64(block.LibNum)
 			}
 
 			bt := block.Time()

--- a/node-manager/monitor_test.go
+++ b/node-manager/monitor_test.go
@@ -1,0 +1,74 @@
+package node_manager
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	pbbstream "github.com/streamingfast/bstream/pb/sf/bstream/v1"
+	"github.com/streamingfast/dmetrics"
+	coremetrics "github.com/streamingfast/firehose-core/metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testAppReadiness avoids a nil dereference in the manager's readiness loop, which
+// kicks in one second after the first block is seen.
+func testAppReadiness(app string) *dmetrics.AppReadiness {
+	return dmetrics.NewSet().NewAppReadiness(app)
+}
+
+func finalizedBlockNumberFor(t *testing.T, reg *prometheus.Registry, app string) (float64, bool) {
+	t.Helper()
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range mfs {
+		if mf.GetName() != "finalized_block_number" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "app" && lp.GetValue() == app {
+					return m.GetGauge().GetValue(), true
+				}
+			}
+		}
+	}
+	return 0, false
+}
+
+func TestMetricsAndReadinessManagerReportsFinalizedBlockNumber(t *testing.T) {
+	const app = "test-finalized-reader"
+
+	finalizedBlockNumber := coremetrics.NewFinalizedBlockNumber(app)
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(finalizedBlockNumber))
+
+	manager := NewMetricsAndReadinessManager(nil, nil, nil, testAppReadiness(app), 0, WithFinalizedBlockNumberMetric(finalizedBlockNumber))
+	go manager.Launch()
+
+	require.NoError(t, manager.UpdateHeadBlock(&pbbstream.Block{Number: 100, LibNum: 90}))
+
+	require.Eventually(t, func() bool {
+		value, found := finalizedBlockNumberFor(t, reg, app)
+		return found && value == 90
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestMetricsAndReadinessManagerWithoutFinalizedBlockNumberMetric(t *testing.T) {
+	const app = "test-finalized-reader-disabled"
+
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(coremetrics.NewFinalizedBlockNumber(app)))
+
+	manager := NewMetricsAndReadinessManager(nil, nil, nil, testAppReadiness(app), 0)
+	go manager.Launch()
+
+	require.NoError(t, manager.UpdateHeadBlock(&pbbstream.Block{Number: 100, LibNum: 90}))
+
+	time.Sleep(100 * time.Millisecond)
+	_, found := finalizedBlockNumberFor(t, reg, app)
+	assert.False(t, found, "no finalized block number must be reported when the option is not given")
+}

--- a/relayer/metrics/metrics.go
+++ b/relayer/metrics/metrics.go
@@ -16,6 +16,7 @@ package metrics
 
 import (
 	"github.com/streamingfast/dmetrics"
+	coremetrics "github.com/streamingfast/firehose-core/metrics"
 )
 
 var MetricSet = dmetrics.NewSet()
@@ -23,4 +24,5 @@ var MetricSet = dmetrics.NewSet()
 var HeadBlockTimeDrift = MetricSet.NewHeadTimeDrift("relayer")
 var HeadBlockNumber = MetricSet.NewHeadBlockNumber("relayer")
 var HeadBlockRelativeDrift = MetricSet.NewHeadBlockRelativeTime("relayer")
+var FinalizedBlockNumber = coremetrics.NewFinalizedBlockNumber("relayer")
 var AppReadiness = MetricSet.NewAppReadiness("relayer")

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -79,6 +79,7 @@ func NewRelayer(
 	options := []forkable.Option{
 		forkable.WithFilters(bstream.StepNew | bstream.StepPartial),
 		forkable.WithMetrics(metrics.HeadBlockNumber, metrics.HeadBlockTimeDrift, metrics.HeadBlockRelativeDrift),
+		forkable.WithFinalizedBlockNumMetric(metrics.FinalizedBlockNumber),
 	}
 
 	forkableHub := hub.NewForkableHubWithOptions(
@@ -146,15 +147,17 @@ func (r *Relayer) Run() {
 
 	// Seed head metrics from the bootstrapped hub head so we report it
 	// immediately, instead of only once a live block flows through the forkable.
-	if headNum, headID, headTime, _, err := r.hub.HeadInfo(); err == nil {
+	if headNum, headID, headTime, libNum, err := r.hub.HeadInfo(); err == nil {
 		zlog.Info("seeding head metrics from hub head",
 			zap.Uint64("head_num", headNum),
 			zap.String("head_id", headID),
 			zap.Time("head_time", headTime),
+			zap.Uint64("lib_num", libNum),
 		)
 		metrics.HeadBlockNumber.SetUint64(headNum)
 		metrics.HeadBlockTimeDrift.SetBlockTime(headTime)
 		metrics.HeadBlockRelativeDrift.SetLastBlock(headTime)
+		metrics.FinalizedBlockNumber.SetUint64(libNum)
 	}
 
 	r.OnTerminating(func(e error) {


### PR DESCRIPTION
## Why

Firehose apps expose `head_block_number{app}`, but nothing on the drift dashboard says how far behind finality that head is. This adds `finalized_block_number{app}` so a dashboard can show head↔finality drift in blocks as `head_block_number - finalized_block_number`, per app.

Block number only: `pbbstream.Block.LibNum` is on every block, so the finalized *number* is available wherever a head number is set today. The finalized *time* is not — `LibNum` carries no timestamp and resolving it needs a forkdb lookup by ID, which only relayer and reader-node could ever satisfy, and only while the LIB block is still in the window. Block number is the finality signal we trust today; seconds-behind-finality can be approximated on the dashboard as blocks × chain block time.

## What

**Metric definition** — new `metrics/` package (`coremetrics`), following the `relayer/metrics/source_drift.go` precedent rather than adding to `dmetrics`: a package-level `GaugeVec` labelled by `app`, registered once at init time, with per-app instances holding only the label value. That registration shape is what keeps it safe when several apps run in one process (`fire{chain} start reader-node,relayer,merger`); registering the collector per `dmetrics.Set` would panic on a duplicate descriptor.

**Reported by:**

| App | Source |
|---|---|
| reader-node, reader-node-stdin, reader-node-firehose | `block.LibNum`, through the node-manager metrics manager |
| firehose | `blk.LibNum` on the block stream handler |
| relayer | `blk.LibNum` on the forkable live path, seeded from the hub head at startup |
| merger, block-indexer | same value as head (see below) |

**Merger and index-builder report finalized == head.** Both only ever process final blocks (index-builder streams with `FinalBlocksOnly`, merger bundles irreversible one-block files), so their head is finalized by construction. They deliberately do *not* publish the LIB number carried by those blocks: that value trails their own head and would make the drift panel read as if the merger were lagging finality.

**No breaking change for chain repositories.** `NewMetricsAndReadinessManager` takes the new metric through a variadic `WithFinalizedBlockNumberMetric(...)` option rather than a sixth positional argument, and `firehose.Modules` gets an optional, nil-guarded field.

**bstream** — the relayer's head metrics are set inside the forkable, so the finalized number is set on the same path via the new `forkable.WithFinalizedBlockNumMetric` option (streamingfast/bstream#61, merged). Computing it relayer-side instead (a ticker, or the per-source handler) would report head and finalized from different observation points.

## Out of scope

- substreams-tier1 / tier2: the head metric is set inside the substreams library.
- `finalized_block_time_drift`: see the reasoning above.

## Tests

- `metrics/finalized_block_test.go`: metric name, `app` label, per-app values.
- `node-manager/monitor_test.go`: the metrics manager reports `LibNum` when the option is given, and reports nothing when it is not.
- bstream side: value set from `LibNum` on the live path, not set when live metrics are off.

The `relayer` e2e test fails locally on `develop` as well (the `dummy-blockchain` container exits 1), unrelated to this change.