### PR TITLE
tools substreams logs connection: show the request's actual logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 - New `finalized_block_number{app}` metric, reported by `reader-node`, `reader-node-stdin`, `reader-node-firehose`, `relayer`, `firehose`, `merger` and `block-indexer`. Paired with the existing `head_block_number{app}`, it lets dashboards show how far behind finality each app's head is, as `head_block_number - finalized_block_number`. The `merger` and `block-indexer` only ever process final blocks, so they report the same value for both.
 
+- `tools substreams logs connection`: new final `Logs` section which asks whether the full logs should be printed (defaults to yes when you just hit enter) and, when declined or when running non-interactively, shows a Cloud Logging console link scoped to the request's own time window instead.
+
+- `tools substreams logs connection`: new `--logs` flag printing every log line of the request (tier1 and tier2 alike) in the final `Logs` section instead of the console link, rendered as `<time> <severity> <logger> <message>` with the remaining fields listed one `<key>: <value>` per line under it, numeric duration fields (`duration`, `parallel_duration`, `time_to_first_data`, ...) being shown as human durations. Use `--logs-limit` (default `500`, `0` disables) to control how many of the most recent lines are printed.
+
 ### Changed
 
 - Bumped `bstream` for `forkable.WithFinalizedBlockNumMetric`, the option backing the new `finalized_block_number` metric on the `relayer`.

--- a/cmd/tools/stylex/stylex.go
+++ b/cmd/tools/stylex/stylex.go
@@ -30,6 +30,12 @@ var (
 	ConnectionOrphanStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("13")) // Magenta
 	ConnectionErrorStyle  = ErrorStyle
 
+	// Styles used when rendering raw log lines, kept desaturated so long log
+	// dumps stay easy on the eyes
+	LogLoggerStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("73"))             // Cadet teal
+	LogKeyStyle    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("252")) // Off-white, emphasized
+	LogValueStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))            // Grey
+
 	separator = "─"
 )
 
@@ -57,6 +63,10 @@ func DisableColors() {
 	ConnectionClosedStyle = lipgloss.NewStyle()
 	ConnectionOrphanStyle = lipgloss.NewStyle()
 	ConnectionErrorStyle = lipgloss.NewStyle()
+
+	LogLoggerStyle = lipgloss.NewStyle()
+	LogKeyStyle = lipgloss.NewStyle()
+	LogValueStyle = lipgloss.NewStyle()
 }
 
 // Titlef is a helper function equivalent to Title.Render(fmt.Sprintf(...))
@@ -187,6 +197,36 @@ func ConnectionErrorf(format string, a ...any) string {
 // ConnectionError is a helper function equivalent to ConnectionError.Render(...)
 func ConnectionError(str string) string {
 	return ConnectionErrorStyle.Render(str)
+}
+
+// LogLoggerf is a helper function equivalent to LogLogger.Render(fmt.Sprintf(...))
+func LogLoggerf(format string, a ...any) string {
+	return LogLoggerStyle.Render(fmt.Sprintf(format, a...))
+}
+
+// LogLogger is a helper function equivalent to LogLogger.Render(...)
+func LogLogger(str string) string {
+	return LogLoggerStyle.Render(str)
+}
+
+// LogKeyf is a helper function equivalent to LogKey.Render(fmt.Sprintf(...))
+func LogKeyf(format string, a ...any) string {
+	return LogKeyStyle.Render(fmt.Sprintf(format, a...))
+}
+
+// LogKey is a helper function equivalent to LogKey.Render(...)
+func LogKey(str string) string {
+	return LogKeyStyle.Render(str)
+}
+
+// LogValuef is a helper function equivalent to LogValue.Render(fmt.Sprintf(...))
+func LogValuef(format string, a ...any) string {
+	return LogValueStyle.Render(fmt.Sprintf(format, a...))
+}
+
+// LogValue is a helper function equivalent to LogValue.Render(...)
+func LogValue(str string) string {
+	return LogValueStyle.Render(str)
 }
 
 func Separator(count int) string {

--- a/cmd/tools/substreams/logs/backend.go
+++ b/cmd/tools/substreams/logs/backend.go
@@ -2,6 +2,7 @@ package logs
 
 import (
 	"context"
+	"time"
 )
 
 // LogEntry represents a raw log entry from any backend
@@ -23,6 +24,10 @@ type LogEntry struct {
 	NoopMode         bool
 	Timestamp        string
 
+	// EntryTime is the timestamp of the log entry itself as recorded by the
+	// backend, used when the payload carries no `timestamp` field
+	EntryTime time.Time
+
 	// Stats-specific fields (only present for "substreams request stats")
 	Tier                 string
 	TotalBlocksProcessed uint64
@@ -36,6 +41,14 @@ type LogEntry struct {
 	Namespace   string
 	ClusterName string
 	PodName     string
+
+	// Severity of the entry as reported by the backend ("INFO", "ERROR", ...),
+	// empty when the backend does not report one
+	Severity string
+
+	// Fields holds every jsonPayload field of the entry, used to render raw
+	// logs. Nil for entries whose payload was not a JSON object.
+	Fields map[string]any
 }
 
 // IsIncomingRequest returns true if this is an incoming request log

--- a/cmd/tools/substreams/logs/console.go
+++ b/cmd/tools/substreams/logs/console.go
@@ -1,0 +1,36 @@
+package logs
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// ConsoleURL returns a Google Cloud Logging "Logs Explorer" URL that opens the
+// browser on the exact same entries the given query options match, so the user
+// can browse the actual logs interactively.
+//
+// The Logs Explorer takes its parameters as `;key=value` path segments, each
+// percent-encoded, with the project passed as a regular query parameter.
+//
+// See https://cloud.google.com/logging/docs/view/logs-explorer-interface
+func ConsoleURL(projectID string, opts QueryOptions) string {
+	timeRange := fmt.Sprintf("%s/%s",
+		opts.StartTime.UTC().Format(time.RFC3339),
+		opts.EndTime.UTC().Format(time.RFC3339),
+	)
+
+	return fmt.Sprintf("https://console.cloud.google.com/logs/query;query=%s;timeRange=%s?project=%s",
+		encodePathParam(BuildFilter(opts)),
+		encodePathParam(timeRange),
+		url.QueryEscape(projectID),
+	)
+}
+
+// encodePathParam percent-encodes a value for use in a `;key=value` path
+// segment. url.QueryEscape encodes spaces as `+`, which is only decoded as a
+// space in query strings, so they are re-encoded as `%20`.
+func encodePathParam(value string) string {
+	return strings.ReplaceAll(url.QueryEscape(value), "+", "%20")
+}

--- a/cmd/tools/substreams/logs/console_test.go
+++ b/cmd/tools/substreams/logs/console_test.go
@@ -1,0 +1,64 @@
+package logs
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildFilterAllMessages(t *testing.T) {
+	start := time.Date(2026, 2, 18, 5, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	t.Run("message restriction is dropped", func(t *testing.T) {
+		f := BuildFilter(QueryOptions{
+			TraceID:     "abc123",
+			StartTime:   start,
+			EndTime:     end,
+			AllMessages: true,
+		})
+
+		assert.Contains(t, f, `SEARCH("abc123")`)
+		assert.NotContains(t, f, "jsonPayload.message")
+		assert.Contains(t, f, `timestamp >= "2026-02-18T05:00:00Z"`)
+		assert.Contains(t, f, `timestamp <= "2026-02-18T06:00:00Z"`)
+	})
+
+	t.Run("message restriction is kept by default", func(t *testing.T) {
+		f := BuildFilter(QueryOptions{TraceID: "abc123", StartTime: start, EndTime: end})
+
+		assert.Contains(t, f, `jsonPayload.message="incoming Substreams Blocks request"`)
+	})
+}
+
+func TestConsoleURL(t *testing.T) {
+	opts := QueryOptions{
+		TraceID:     "abc123",
+		StartTime:   time.Date(2026, 2, 18, 5, 0, 0, 0, time.UTC),
+		EndTime:     time.Date(2026, 2, 18, 6, 0, 0, 0, time.UTC),
+		AllMessages: true,
+	}
+
+	got := ConsoleURL("my-project", opts)
+
+	require.True(t, strings.HasPrefix(got, "https://console.cloud.google.com/logs/query;query="), got)
+	assert.True(t, strings.HasSuffix(got, "?project=my-project"), got)
+	assert.NotContains(t, got, "+", "spaces must be percent-encoded, not turned into '+'")
+
+	// The query segment must decode back to the exact filter we would query with
+	querySegment := strings.TrimSuffix(strings.TrimPrefix(got, "https://console.cloud.google.com/logs/query;query="), "?project=my-project")
+	encodedQuery, encodedTimeRange, found := strings.Cut(querySegment, ";timeRange=")
+	require.True(t, found, "URL must carry a timeRange segment: %s", got)
+
+	decodedQuery, err := url.QueryUnescape(encodedQuery)
+	require.NoError(t, err)
+	assert.Equal(t, BuildFilter(opts), decodedQuery)
+
+	decodedTimeRange, err := url.QueryUnescape(encodedTimeRange)
+	require.NoError(t, err)
+	assert.Equal(t, "2026-02-18T05:00:00Z/2026-02-18T06:00:00Z", decodedTimeRange)
+}

--- a/cmd/tools/substreams/logs/gcp_backend.go
+++ b/cmd/tools/substreams/logs/gcp_backend.go
@@ -37,10 +37,11 @@ func NewGCPBackend(ctx context.Context, projectID string, logger *zap.Logger) (*
 
 // QueryLogs queries Cloud Logging for connection-related log entries
 func (b *GCPBackend) QueryLogs(ctx context.Context, opts QueryOptions) ([]LogEntry, error) {
-	filter := b.buildFilter(opts)
+	filter := BuildFilter(opts)
 	b.logger.Debug("querying GCP Cloud Logging",
 		zap.String("project_id", b.projectID),
 		zap.String("filter", filter),
+		zap.Int("limit", opts.Limit),
 	)
 
 	var entries []LogEntry
@@ -49,6 +50,11 @@ func (b *GCPBackend) QueryLogs(ctx context.Context, opts QueryOptions) ([]LogEnt
 			return nil, fmt.Errorf("iterating log entries: %w", err)
 		}
 		entries = append(entries, entry)
+
+		// Entries are returned newest first, so capping here keeps the most recent ones
+		if opts.Limit > 0 && len(entries) >= opts.Limit {
+			break
+		}
 	}
 
 	b.logger.Debug("query completed", zap.Int("entries_found", len(entries)))
@@ -78,11 +84,16 @@ func (b *GCPBackend) iterateEntries(ctx context.Context, filter string) iter.Seq
 	}
 }
 
-// buildFilter constructs the Cloud Logging filter string
+// BuildFilter constructs the Cloud Logging filter string
 //
 // When TraceID is set, filters by SEARCH() across the entry payload. Otherwise
-// filters by jsonPayload.user_id.
-func (b *GCPBackend) buildFilter(opts QueryOptions) string {
+// filters by jsonPayload.user_id. When AllMessages is set, the filter is not
+// restricted to the incoming-request/request-stats messages, returning every
+// log entry of the matched request instead.
+//
+// The filter is exported because it is also rendered back to the user, both as
+// a Cloud Logging console link and as a `gcloud logging read` invocation.
+func BuildFilter(opts QueryOptions) string {
 	var subjectFilter string
 	if opts.TraceID != "" {
 		subjectFilter = fmt.Sprintf(`SEARCH("%s")`, escapeFilterValue(opts.TraceID))
@@ -90,15 +101,21 @@ func (b *GCPBackend) buildFilter(opts QueryOptions) string {
 		subjectFilter = fmt.Sprintf(`jsonPayload.user_id="%s"`, escapeFilterValue(opts.UserID))
 	}
 
-	filter := fmt.Sprintf(`resource.type="k8s_container"
-%s
+	messageFilter := `
 (
   jsonPayload.message="incoming Substreams Blocks request" OR
   (jsonPayload.message="substreams request stats" AND jsonPayload.tier="tier1")
-)
+)`
+	if opts.AllMessages {
+		messageFilter = ""
+	}
+
+	filter := fmt.Sprintf(`resource.type="k8s_container"
+%s%s
 timestamp >= "%s"
 timestamp <= "%s"`,
 		subjectFilter,
+		messageFilter,
 		opts.StartTime.Format(time.RFC3339),
 		opts.EndTime.Format(time.RFC3339),
 	)
@@ -132,7 +149,11 @@ func escapeFilterValue(s string) string {
 
 // parseEntry extracts fields from a Cloud Logging entry into a LogEntry
 func (b *GCPBackend) parseEntry(entry *logging.Entry) LogEntry {
-	le := LogEntry{}
+	le := LogEntry{
+		EntryTime: entry.Timestamp,
+		Severity:  severityString(entry.Severity),
+	}
+	le.Namespace, le.ClusterName, le.PodName = resourceLabels(entry)
 
 	// Extract jsonPayload fields
 	// Cloud Logging returns Payload as *structpb.Struct for JSON logs
@@ -142,10 +163,15 @@ func (b *GCPBackend) parseEntry(entry *logging.Entry) LogEntry {
 		payload = p.AsMap()
 	case map[string]any:
 		payload = p
+	case string:
+		// Plain text payload, only reachable when querying every message of a request
+		le.Message = p
+		return le
 	default:
 		b.logger.Debug("unknown payload type", zap.String("type", fmt.Sprintf("%T", entry.Payload)))
 		return le
 	}
+	le.Fields = payload
 
 	// Trace log the raw entry for debugging
 	if b.logger.Core().Enabled(zap.DebugLevel) {
@@ -195,14 +221,28 @@ func (b *GCPBackend) parseEntry(entry *logging.Entry) LogEntry {
 		zap.String("tier", le.Tier),
 	)
 
-	// Extract resource labels (GCP-specific envelope)
-	if entry.Resource != nil && entry.Resource.Labels != nil {
-		le.Namespace = entry.Resource.Labels["namespace_name"]
-		le.ClusterName = entry.Resource.Labels["cluster_name"]
-		le.PodName = entry.Resource.Labels["pod_name"]
+	return le
+}
+
+// resourceLabels extracts the GCP-specific resource envelope labels
+func resourceLabels(entry *logging.Entry) (namespace, cluster, pod string) {
+	if entry.Resource == nil || entry.Resource.Labels == nil {
+		return "", "", ""
 	}
 
-	return le
+	labels := entry.Resource.Labels
+	return labels["namespace_name"], labels["cluster_name"], labels["pod_name"]
+}
+
+// severityString renders a Cloud Logging severity, mapping the "no severity
+// reported" default to an empty string. The client renders severities in title
+// case ("Info", "Warning"), they are upper-cased to match how Cloud Logging
+// itself names them.
+func severityString(severity logging.Severity) string {
+	if severity == logging.Default {
+		return ""
+	}
+	return strings.ToUpper(severity.String())
 }
 
 // Close releases resources held by the backend

--- a/cmd/tools/substreams/logs/gcp_backend_test.go
+++ b/cmd/tools/substreams/logs/gcp_backend_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/logging"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,12 +34,11 @@ jsonPayload.message="X`, `evil\"jsonPayload.message=\"X`},
 }
 
 func TestBuildFilterEscapesValues(t *testing.T) {
-	b := &GCPBackend{}
 	start := time.Date(2026, 2, 18, 5, 0, 0, 0, time.UTC)
 	end := start.Add(time.Hour)
 
 	t.Run("trace id with quote/backslash is escaped", func(t *testing.T) {
-		f := b.buildFilter(QueryOptions{
+		f := BuildFilter(QueryOptions{
 			TraceID:   `evil"\`,
 			StartTime: start,
 			EndTime:   end,
@@ -47,7 +47,7 @@ func TestBuildFilterEscapesValues(t *testing.T) {
 	})
 
 	t.Run("user id with quote is escaped", func(t *testing.T) {
-		f := b.buildFilter(QueryOptions{
+		f := BuildFilter(QueryOptions{
 			UserID:    `org"injected`,
 			StartTime: start,
 			EndTime:   end,
@@ -56,7 +56,7 @@ func TestBuildFilterEscapesValues(t *testing.T) {
 	})
 
 	t.Run("namespace with quote is escaped", func(t *testing.T) {
-		f := b.buildFilter(QueryOptions{
+		f := BuildFilter(QueryOptions{
 			UserID:    "sfinfra",
 			Namespace: `evil"ns`,
 			StartTime: start,
@@ -66,7 +66,7 @@ func TestBuildFilterEscapesValues(t *testing.T) {
 	})
 
 	t.Run("trace id wins over user id", func(t *testing.T) {
-		f := b.buildFilter(QueryOptions{
+		f := BuildFilter(QueryOptions{
 			TraceID:   "abc123",
 			UserID:    "should-be-ignored",
 			StartTime: start,
@@ -75,4 +75,23 @@ func TestBuildFilterEscapesValues(t *testing.T) {
 		assert.Contains(t, f, `SEARCH("abc123")`)
 		assert.NotContains(t, f, "should-be-ignored")
 	})
+}
+
+func TestSeverityString(t *testing.T) {
+	tests := []struct {
+		name string
+		in   logging.Severity
+		want string
+	}{
+		{"default is empty", logging.Default, ""},
+		{"info is upper-cased", logging.Info, "INFO"},
+		{"warning is upper-cased", logging.Warning, "WARNING"},
+		{"error is upper-cased", logging.Error, "ERROR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, severityString(tt.in))
+		})
+	}
 }

--- a/cmd/tools/substreams/logs/types.go
+++ b/cmd/tools/substreams/logs/types.go
@@ -24,6 +24,15 @@ type QueryOptions struct {
 	Namespace string
 	StartTime time.Time
 	EndTime   time.Time
+
+	// AllMessages disables the "incoming request"/"request stats" message
+	// restriction, returning every log entry matching the subject (trace ID or
+	// user ID) instead. Used to display the raw logs of a single request.
+	AllMessages bool
+
+	// Limit caps the number of entries returned, keeping the newest ones. Zero
+	// means no limit.
+	Limit int
 }
 
 // ConnectionLog represents a single connection (may be partial if stats not yet received)

--- a/cmd/tools/substreams/logs_connection.go
+++ b/cmd/tools/substreams/logs_connection.go
@@ -2,10 +2,14 @@ package substreams
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
+	"github.com/streamingfast/cli"
 	"github.com/streamingfast/cli/sflags"
 	"github.com/streamingfast/firehose-core/cmd/tools/stylex"
 	"github.com/streamingfast/firehose-core/cmd/tools/substreams/logs"
@@ -38,7 +42,11 @@ The date-range argument(s) accept various formats:
 
   firecore tools substreams logs connection bfb0980c436f3fd6f5564a31311d583f 2h \
     --state-store gs://my-bucket/substreams-states \
-    --gcp-project my-project`,
+    --gcp-project my-project
+
+  # Print every log line of the request at the end of the report
+  firecore tools substreams logs connection bfb0980c436f3fd6f5564a31311d583f \
+    --gcp-project my-project --logs`,
 		Args: cobra.RangeArgs(1, 3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runConnection(cmd.Context(), args, cmd, logger)
@@ -47,6 +55,8 @@ The date-range argument(s) accept various formats:
 
 	cmd.Flags().String("state-store", "", "State store URL where spkg files are stored (supports file:// and gs://). When set, the spkg is loaded to display the package name and full URL")
 	cmd.Flags().String("gcp-project", "", "GCP project ID used for log querying")
+	cmd.Flags().Bool("logs", false, "Print every log line of the request in a final 'Logs' section")
+	cmd.Flags().Int("logs-limit", 500, "Maximum number of log lines to print with --logs, keeping the most recent ones (0 means no limit)")
 	cmd.MarkFlagRequired("gcp-project")
 
 	return cmd
@@ -62,6 +72,12 @@ func runConnection(ctx context.Context, args []string, cmd *cobra.Command, logge
 
 	stateStore := sflags.MustGetString(cmd, "state-store")
 	gcpProject := sflags.MustGetString(cmd, "gcp-project")
+	showLogs := sflags.MustGetBool(cmd, "logs")
+	logsLimit := sflags.MustGetInt(cmd, "logs-limit")
+
+	if logsLimit < 0 {
+		return fmt.Errorf("--logs-limit must be greater than or equal to 0, got %d", logsLimit)
+	}
 
 	var startTime, endTime time.Time
 	if len(dateArgs) == 0 {
@@ -165,7 +181,107 @@ func runConnection(ctx context.Context, args []string, cmd *cobra.Command, logge
 		}
 	}
 
+	// Raw logs of the request itself, both as browsable links and, on demand, inlined
+	rawOpts := logs.QueryOptions{
+		TraceID:     traceID,
+		AllMessages: true,
+		Limit:       logsLimit,
+	}
+	rawOpts.StartTime, rawOpts.EndTime = requestLogWindow(request, stats, startTime, endTime)
+
+	fmt.Println()
+	fmt.Println(stylex.Header("Logs"))
+
+	// Without --logs, offer to print them anyway, falling back on the console
+	// link when the answer is no (or when nobody is there to answer)
+	if !showLogs && !promptShowLogs() {
+		fmt.Printf("%s %s\n", stylex.Label("Console:"), stylex.Value(logs.ConsoleURL(gcpProject, rawOpts)))
+		fmt.Println(stylex.Note("Pass --logs to print the log lines here right away"))
+		return nil
+	}
+
+	fmt.Print(stylex.Label("Fetching logs... "))
+	rawEntries, err := backend.QueryLogs(ctx, rawOpts)
+	if err != nil {
+		fmt.Println(stylex.Error("✗"))
+		return fmt.Errorf("querying raw logs: %w", err)
+	}
+	fmt.Println(stylex.Success("✓"))
+
+	if logsLimit > 0 && len(rawEntries) >= logsLimit {
+		fmt.Printf("%s\n", stylex.Warnf("Truncated to the %d most recent log lines — raise or disable it with --logs-limit", logsLimit))
+	}
+	fmt.Println()
+
+	printRawLogs(rawEntries)
+
 	return nil
+}
+
+// promptShowLogs asks whether the full logs should be printed, defaulting to
+// yes. Returns false when there is nobody to answer (output is not a terminal)
+// or when the prompt could not be run at all, the console link is shown in
+// those cases.
+func promptShowLogs() bool {
+	if !stylex.IsTTY {
+		return false
+	}
+
+	confirmTemplate := `{{ "?" | blue }} {{ . | bold }} {{ "[Y/n]" | faint }} `
+	answer, err := cli.MaybePrompt("Show the full logs?", promptAnswerYesByDefault,
+		cli.WithPromptValidate("answer with y/yes or n/no", validatePromptYesNoOrEmpty),
+		cli.WithPromptTemplates(&promptui.PromptTemplates{
+			Valid:   confirmTemplate,
+			Invalid: confirmTemplate,
+			Success: `{{ . | faint }}{{ ":" | faint }} `,
+		}),
+	)
+	if err != nil {
+		return false
+	}
+
+	return answer
+}
+
+// promptAnswerYesByDefault turns a yes/no answer into a boolean, an empty
+// answer (the user just hit enter) meaning yes
+func promptAnswerYesByDefault(answer string) (bool, error) {
+	answer = strings.ToLower(strings.TrimSpace(answer))
+
+	return answer == "" || answer == "y" || answer == "yes", nil
+}
+
+// validatePromptYesNoOrEmpty accepts a yes/no answer as well as an empty one,
+// which stands for the default
+func validatePromptYesNoOrEmpty(answer string) error {
+	switch strings.ToLower(strings.TrimSpace(answer)) {
+	case "", "y", "yes", "n", "no":
+		return nil
+	default:
+		return errors.New("answer with y/yes or n/no")
+	}
+}
+
+// requestLogWindow narrows the time range to the request's own lifetime, padded
+// on both sides so the surrounding lines are visible. Falls back to the queried
+// range when the corresponding log is missing (e.g. a still-running request has
+// no stats log yet).
+func requestLogWindow(request, stats *logs.LogEntry, startTime, endTime time.Time) (time.Time, time.Time) {
+	const padding = time.Minute
+
+	windowStart, windowEnd := startTime, endTime
+	if request != nil {
+		if ts, ok := parseLogTimestamp(request.Timestamp); ok {
+			windowStart = ts.Add(-padding)
+		}
+	}
+	if stats != nil {
+		if ts, ok := parseLogTimestamp(stats.Timestamp); ok {
+			windowEnd = ts.Add(padding)
+		}
+	}
+
+	return windowStart, windowEnd
 }
 
 // pickConnectionEntries selects the oldest incoming-request log and the most

--- a/cmd/tools/substreams/logs_connection_test.go
+++ b/cmd/tools/substreams/logs_connection_test.go
@@ -25,6 +25,58 @@ func TestNewToolsLogsConnectionCmd(t *testing.T) {
 
 	gcpProjectFlag := flags.Lookup("gcp-project")
 	require.NotNil(t, gcpProjectFlag, "gcp-project flag should exist")
+
+	logsFlag := flags.Lookup("logs")
+	require.NotNil(t, logsFlag, "logs flag should exist")
+	assert.Equal(t, "false", logsFlag.DefValue)
+
+	logsLimitFlag := flags.Lookup("logs-limit")
+	require.NotNil(t, logsLimitFlag, "logs-limit flag should exist")
+	assert.Equal(t, "500", logsLimitFlag.DefValue)
+}
+
+func TestRequestLogWindow(t *testing.T) {
+	startTime := time.Date(2026, 2, 18, 0, 0, 0, 0, time.UTC)
+	endTime := time.Date(2026, 2, 18, 12, 0, 0, 0, time.UTC)
+	at := func(hour int) string {
+		return time.Date(2026, 2, 18, hour, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	}
+
+	t.Run("narrows to padded request lifetime", func(t *testing.T) {
+		start, end := requestLogWindow(
+			&logs.LogEntry{Timestamp: at(5)},
+			&logs.LogEntry{Timestamp: at(6)},
+			startTime, endTime,
+		)
+
+		assert.Equal(t, time.Date(2026, 2, 18, 4, 59, 0, 0, time.UTC), start.UTC())
+		assert.Equal(t, time.Date(2026, 2, 18, 6, 1, 0, 0, time.UTC), end.UTC())
+	})
+
+	t.Run("keeps queried end when request is still running", func(t *testing.T) {
+		start, end := requestLogWindow(&logs.LogEntry{Timestamp: at(5)}, nil, startTime, endTime)
+
+		assert.Equal(t, time.Date(2026, 2, 18, 4, 59, 0, 0, time.UTC), start.UTC())
+		assert.Equal(t, endTime, end.UTC())
+	})
+
+	t.Run("falls back on queried range", func(t *testing.T) {
+		start, end := requestLogWindow(nil, nil, startTime, endTime)
+
+		assert.Equal(t, startTime, start.UTC())
+		assert.Equal(t, endTime, end.UTC())
+	})
+
+	t.Run("falls back on queried bounds when timestamps are unparseable", func(t *testing.T) {
+		start, end := requestLogWindow(
+			&logs.LogEntry{Timestamp: "nope"},
+			&logs.LogEntry{Timestamp: "nope"},
+			startTime, endTime,
+		)
+
+		assert.Equal(t, startTime, start.UTC())
+		assert.Equal(t, endTime, end.UTC())
+	})
 }
 
 func TestConnectionCommandHelp(t *testing.T) {

--- a/cmd/tools/substreams/logs_raw.go
+++ b/cmd/tools/substreams/logs_raw.go
@@ -1,0 +1,195 @@
+package substreams
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/streamingfast/firehose-core/cmd/tools/stylex"
+	"github.com/streamingfast/firehose-core/cmd/tools/substreams/logs"
+)
+
+// rawLogSkippedFields are payload fields already rendered on their own by
+// printRawLogs, or pure noise when reading a single request's logs
+var rawLogSkippedFields = map[string]bool{
+	"message":   true,
+	"timestamp": true,
+	"severity":  true,
+	"level":     true,
+	"logger":    true,
+	"trace_id":  true,
+}
+
+const (
+	// rawLogFieldIndent prefixes each field rendered under a message
+	rawLogFieldIndent = "    "
+
+	// rawLogTimeFormat is the local-time layout each log line starts with, the
+	// timezone is kept so the lines can be matched against other tools
+	rawLogTimeFormat = "2006-01-02 15:04:05.000 MST"
+
+	// maxRawLogDurationSeconds is the value above which a duration-looking field
+	// is left as-is, an epoch timestamp landing on such a key would otherwise be
+	// rendered as a decades-long duration
+	maxRawLogDurationSeconds = float64(10 * 365 * 24 * 60 * 60)
+)
+
+// rawLogField is a single payload field, ready to be rendered
+type rawLogField struct {
+	Key   string
+	Value string
+}
+
+// printRawLogs renders log entries oldest first as
+// `<time> <severity> <logger> <message>`, with the remaining payload fields
+// listed one per line under it.
+func printRawLogs(entries []logs.LogEntry) {
+	if len(entries) == 0 {
+		fmt.Println(stylex.Note("No log entry found for this trace ID in the given time range"))
+		return
+	}
+
+	sorted := slices.Clone(entries)
+	slices.SortStableFunc(sorted, func(a, b logs.LogEntry) int {
+		return rawLogTime(a).Compare(rawLogTime(b))
+	})
+
+	for _, entry := range sorted {
+		fmt.Printf("%s %s %s%s\n",
+			rawLogTime(entry).Local().Format(rawLogTimeFormat),
+			formatSeverity(entry.Severity),
+			formatLogger(entry.Fields),
+			entry.Message,
+		)
+
+		printRawLogFieldLines(rawLogFields(entry.Fields))
+	}
+}
+
+// rawLogTime returns the entry's payload timestamp, falling back to the
+// timestamp recorded by the backend when the payload carries none
+func rawLogTime(entry logs.LogEntry) time.Time {
+	if ts, ok := parseLogTimestamp(entry.Timestamp); ok {
+		return ts
+	}
+	return entry.EntryTime
+}
+
+// formatSeverity renders the severity, colored by importance
+func formatSeverity(severity string) string {
+	if severity == "" {
+		severity = "-"
+	}
+
+	switch severity {
+	case "ERROR", "CRITICAL", "ALERT", "EMERGENCY":
+		return stylex.Error(severity)
+	case "WARNING":
+		return stylex.Warn(severity)
+	case "DEBUG":
+		return stylex.Dim(severity)
+	default:
+		return stylex.Success(severity)
+	}
+}
+
+// formatLogger renders the `logger` field between parenthesis ahead of the
+// message, returning an empty string when the entry carries none
+func formatLogger(fields map[string]any) string {
+	logger, ok := fields["logger"].(string)
+	if !ok || logger == "" {
+		return ""
+	}
+
+	return stylex.LogLoggerf("(%s) ", logger)
+}
+
+// rawLogFields returns the payload fields left to render, sorted by key so
+// successive runs are comparable
+func rawLogFields(fields map[string]any) []rawLogField {
+	if len(fields) == 0 {
+		return nil
+	}
+
+	out := make([]rawLogField, 0, len(fields))
+	for _, key := range slices.Sorted(maps.Keys(fields)) {
+		if rawLogSkippedFields[key] || strings.HasPrefix(key, "logging.googleapis.com/") {
+			continue
+		}
+
+		out = append(out, rawLogField{Key: key, Value: formatRawLogFieldValue(key, fields[key])})
+	}
+
+	return out
+}
+
+// printRawLogFieldLines renders one `<key>: <value>` per line under the
+// message, keys and values colored apart
+func printRawLogFieldLines(fields []rawLogField) {
+	for _, field := range fields {
+		fmt.Printf("%s%s %s\n", rawLogFieldIndent, stylex.LogKeyf("%s:", field.Key), stylex.LogValue(field.Value))
+	}
+}
+
+// formatRawLogFieldValue renders a payload value, rendering the numeric ones
+// held by a duration-looking key as a human duration
+func formatRawLogFieldValue(key string, value any) string {
+	if seconds, ok := value.(float64); ok && isDurationKey(key) && seconds < maxRawLogDurationSeconds {
+		return formatLogDuration(seconds)
+	}
+
+	return formatRawLogValue(value)
+}
+
+// isDurationKey reports whether the field is a duration expressed in seconds,
+// keys carrying an explicit sub-second unit are left alone since they are not
+// in seconds
+func isDurationKey(key string) bool {
+	for _, suffix := range []string{"_ms", "_us", "_ns", "_millis", "_milliseconds", "_micros", "_nanos"} {
+		if strings.HasSuffix(key, suffix) {
+			return false
+		}
+	}
+
+	return strings.Contains(key, "duration") ||
+		strings.Contains(key, "elapsed") ||
+		strings.Contains(key, "latency") ||
+		strings.HasPrefix(key, "time_to") ||
+		strings.Contains(key, "_time_")
+}
+
+// formatLogDuration renders a duration expressed in seconds, keeping the
+// sub-millisecond ones readable (`formatDuration` would floor them to `0ms`)
+func formatLogDuration(seconds float64) string {
+	duration := time.Duration(seconds * float64(time.Second))
+	if duration > -time.Millisecond && duration < time.Millisecond {
+		return duration.String()
+	}
+
+	return formatDuration(duration)
+}
+
+// formatRawLogValue renders a single payload value. Values are printed as-is,
+// neither truncated nor quoted, so long payloads (module stats, errors) stay
+// readable.
+func formatRawLogValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(v)
+	case nil:
+		return "null"
+	default:
+		if encoded, err := json.Marshal(v); err == nil {
+			return string(encoded)
+		}
+		return fmt.Sprintf("%v", v)
+	}
+}

--- a/cmd/tools/substreams/logs_raw_test.go
+++ b/cmd/tools/substreams/logs_raw_test.go
@@ -1,0 +1,160 @@
+package substreams
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/streamingfast/firehose-core/cmd/tools/substreams/logs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRawLogTime(t *testing.T) {
+	entryTime := time.Date(2026, 2, 18, 5, 0, 0, 0, time.UTC)
+
+	t.Run("payload timestamp wins", func(t *testing.T) {
+		got := rawLogTime(logs.LogEntry{Timestamp: "2026-02-18T06:30:00.250Z", EntryTime: entryTime})
+
+		assert.Equal(t, time.Date(2026, 2, 18, 6, 30, 0, 250000000, time.UTC), got.UTC())
+	})
+
+	t.Run("falls back on entry time", func(t *testing.T) {
+		assert.Equal(t, entryTime, rawLogTime(logs.LogEntry{EntryTime: entryTime}))
+	})
+
+	t.Run("falls back on entry time when payload timestamp is unparseable", func(t *testing.T) {
+		assert.Equal(t, entryTime, rawLogTime(logs.LogEntry{Timestamp: "not-a-date", EntryTime: entryTime}))
+	})
+}
+
+func TestFormatSeverity(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"info", "INFO", "INFO"},
+		{"error", "ERROR", "ERROR"},
+		{"warning", "WARNING", "WARNING"},
+		{"emergency", "EMERGENCY", "EMERGENCY"},
+		{"empty becomes dash", "", "-"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formatSeverity(tt.in))
+		})
+	}
+}
+
+func TestFormatLogger(t *testing.T) {
+	t.Run("renders logger between parenthesis with trailing space", func(t *testing.T) {
+		assert.Equal(t, "(substreams-tier1.tier1-grpc) ", formatLogger(map[string]any{"logger": "substreams-tier1.tier1-grpc"}))
+	})
+
+	t.Run("no logger field", func(t *testing.T) {
+		assert.Empty(t, formatLogger(map[string]any{"tier": "tier1"}))
+	})
+
+	t.Run("logger is not a string", func(t *testing.T) {
+		assert.Empty(t, formatLogger(map[string]any{"logger": float64(1)}))
+	})
+}
+
+func TestFormatRawLogValue(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"string", "tier1", "tier1"},
+		{"string with space is left as-is", "context canceled", "context canceled"},
+		{"string with quotes is not escaped", `{"rpc:eth_call": {"count": 2}}`, `{"rpc:eth_call": {"count": 2}}`},
+		{"integral float has no decimals", float64(12), "12"},
+		{"fractional float", 1.25, "1.25"},
+		{"bool", true, "true"},
+		{"nil", nil, "null"},
+		{"nested value is json encoded", map[string]any{"a": float64(1)}, `{"a":1}`},
+		{"long value is not truncated", strings.Repeat("a", 200), strings.Repeat("a", 200)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formatRawLogValue(tt.in))
+		})
+	}
+}
+
+func TestRawLogFields(t *testing.T) {
+	t.Run("no fields", func(t *testing.T) {
+		assert.Empty(t, rawLogFields(nil))
+	})
+
+	t.Run("sorted, skipping rendered and internal fields", func(t *testing.T) {
+		got := rawLogFields(map[string]any{
+			"message":                             "substreams request stats",
+			"timestamp":                           "2026-02-18T05:00:00Z",
+			"severity":                            "INFO",
+			"level":                               "info",
+			"logger":                              "substreams-tier1.tier1-grpc",
+			"trace_id":                            "abc123",
+			"logging.googleapis.com/sourceConfig": "noise",
+			"tier":                                "tier1",
+			"module":                              "map_out",
+		})
+
+		assert.Equal(t, []rawLogField{
+			{Key: "module", Value: "map_out"},
+			{Key: "tier", Value: "tier1"},
+		}, got)
+	})
+}
+
+func TestIsDurationKey(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"duration", "duration", true},
+		{"prefixed duration", "parallel_duration", true},
+		{"module exec duration", "module_exec_duration", true},
+		{"time to first data", "time_to_first_data", true},
+		{"embedded time", "client_read_average_time_last_5_minutes", true},
+		{"elapsed", "elapsed_since_start", true},
+		{"latency", "read_latency", true},
+		{"explicit milliseconds are not seconds", "processing_time_ms", false},
+		{"explicit nanoseconds are not seconds", "exec_duration_ns", false},
+		{"unrelated key", "processed_blocks", false},
+		{"timestamp-ish key", "last_sent_block_time", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isDurationKey(tt.in))
+		})
+	}
+}
+
+func TestFormatRawLogFieldValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value any
+		want  string
+	}{
+		{"seconds become a duration", "duration", 3042.668484665, "50m42s"},
+		{"sub-second duration", "parallel_duration", 0.25, "250ms"},
+		{"sub-millisecond duration keeps its unit", "client_read_average_time_last_5_minutes", 0.000037998, "37.998µs"},
+		{"zero duration", "time_to_first_data", float64(0), "0s"},
+		{"epoch-looking value is left alone", "elapsed_time_since_epoch", 1.7e9, "1700000000"},
+		{"non-numeric duration is left alone", "duration", "a while", "a while"},
+		{"non-duration key is left alone", "processed_blocks", float64(237), "237"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formatRawLogFieldValue(tt.key, tt.value))
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -249,7 +249,7 @@ require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/manifoldco/promptui v0.9.0 // indirect
+	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect


### PR DESCRIPTION
## What

`firecore tools substreams logs connection <trace-id>` now ends with a **Logs** section giving access to the request's actual log lines, instead of stopping at the request/stats summary.

Without `--logs`, the section asks whether the full logs should be printed (enter defaults to yes). Declining — or running non-interactively, e.g. piped output — prints a Cloud Logging console link instead, scoped to the request's own time window (request start → stats end, padded a minute on each side):

```
Logs
? Show the full logs? [Y/n]
Console: https://console.cloud.google.com/logs/query;query=...;timeRange=...?project=dfuseio-global
Pass --logs to print the log lines here right away
```

With `--logs`, every log line of the request is printed — tier1 and tier2 alike — oldest first:

```
2026-07-30 10:14:37.065 EDT WARNING (substreams-tier1.tier1-grpc) incomplete job
    duration: 50m52s
    error: context canceled
    module_name: ["map_token_balances"]
    number_of_tries: 4
    unit: {"segment":25643,"stage":0}
```

- `<time> <severity> <logger> <message>` header, remaining payload fields listed one `<key>: <value>` per line
- values are printed in full — never truncated nor escaped — so long errors and module stats stay readable
- numeric duration fields (`duration`, `parallel_duration`, `time_to_first_data`, `client_read_average_time_last_5_minutes`, ...) are rendered as human durations; keys carrying an explicit sub-second unit (`_ms`, `_ns`, ...) and epoch-sized values are left alone
- `--logs-limit` (default `500`, `0` disables) caps how many of the most recent lines are kept, warning when it truncates

## How

- `logs.QueryOptions` gained `AllMessages` (drops the incoming-request/request-stats message restriction, returning every entry of the request) and `Limit`
- `buildFilter` became the exported `BuildFilter` so the same filter backs both the query and the console link
- `LogEntry` now carries the entry `Severity`, its backend `EntryTime` and the raw jsonPayload `Fields`; text payloads are handled too
- new `logs.ConsoleURL` builds the Logs Explorer URL (percent-encoded `;query=`/`;timeRange=` path segments)
- rendering lives in `cmd/tools/substreams/logs_raw.go`, colors in `stylex`

## Testing

- Unit tests for the filter, console URL, log window narrowing, severity mapping, field selection, value and duration formatting
- Exercised end to end against a real trace in `dfuseio-global`, both answers of the prompt and the non-interactive path

Note: the interactive "enter means yes" path was verified by code and by the declined/non-interactive paths, but real keypresses could not be emulated in my environment — worth one manual run.