### PR TITLE
rpc: named providers and explicit failback reset for the Clients pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 ### Changed
 
-- `rpc.WithClients`/`rpc.WithClientsContext` now attribute each failed attempt to its provider, the returned error reads `provider "<name>": <error>`, and each roll to another provider is logged at `warn` level with the `from_provider`/`to_provider` names. A given `from -> to` roll is logged at most once every 30s (the ones in between are logged at `debug` level and counted as `suppressed_rolls` on the next warning), so a permanently down provider does not warn on every single call.
+- `rpc.WithClients`/`rpc.WithClientsContext` now attribute each failed attempt to its provider, the returned error reads `provider "<name>": <error>`, and each roll to another provider is logged at `warn` level with the `from_provider`/`to_provider` names. A given `from -> to` roll only warns again once 30s elapsed since the last time it did (the ones in between are logged at `debug` level), so a permanently down provider does not warn on every single call.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 ### Changed
 
-- `rpc.WithClients`/`rpc.WithClientsContext` now attribute each failed attempt to its provider, the returned error reads `provider "<name>": <error>`, and each roll to another provider is logged at `warn` level with the `from_provider`/`to_provider` names.
+- `rpc.WithClients`/`rpc.WithClientsContext` now attribute each failed attempt to its provider, the returned error reads `provider "<name>": <error>`, and each roll to another provider is logged at `warn` level with the `from_provider`/`to_provider` names. A given `from -> to` roll is logged at most once every 30s (the ones in between are logged at `debug` level and counted as `suppressed_rolls` on the next warning), so a permanently down provider does not warn on every single call.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 - `rpc.WithClients`/`rpc.WithClientsContext` now attribute each failed attempt to its provider, the returned error reads `provider "<name>": <error>`, and each roll to another provider is logged at `warn` level with the `from_provider`/`to_provider` names.
 
+### Fixed
+
+- `rpc.Sort` no longer reads the clients pool without holding the lock, which was a data race against `Add`/`AddNamed` and against the client selection in `WithClientsContext`, since `StartSorting` runs `Sort` on its own goroutine. It now sorts a snapshot taken under the lock, keeping the per-client network fetches lock-free.
+
+- A client added to the pool while `rpc.Sort` was running is no longer dropped. `Sort` snapshots the pool, fetches a sort value per client over the network, then writes the pool back, and that write used to overwrite anything appended in between. It now redoes the round instead of publishing, so the new client is sorted along with the rest.
+
 ## v1.16.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Operators, you should copy/paste content of this content straight to your projec
 
 If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you should copy the content between those 2 version to your own repository, replacing placeholder value `fire{chain}` with your chain's own binary.
 
+## Unreleased
+
+### Added
+
+- `rpc.Clients` now tracks a provider name per client. New `AddNamed(client, name)` registers a client under an explicit name, `Add(client)` keeps working unchanged and auto-names the client `client-<index>`, and `Names()` returns all provider names in pool order.
+
+- `rpc.Clients.Reset()` brings the rolling strategy back to the pool's declared order, so the next call goes to the primary provider again. Without it, a `StickyRollingStrategy` that rolled to a fallback after a single transient error stayed on that fallback until the process restarted. `StartSorting` now uses it instead of resetting the strategy itself.
+
+### Changed
+
+- `rpc.WithClients`/`rpc.WithClientsContext` now attribute each failed attempt to its provider, the returned error reads `provider "<name>": <error>`, and each roll to another provider is logged at `warn` level with the `from_provider`/`to_provider` names.
+
 ## v1.16.1
 
 ### Added

--- a/rpc/clients.go
+++ b/rpc/clients.go
@@ -14,9 +14,9 @@ import (
 
 var ErrorNoMoreClient = errors.New("no more clients")
 
-// defaultRollLogSamplingInterval is how often at most a given `from -> to` roll is
-// logged at `warn` level, see [Clients.logRoll].
-const defaultRollLogSamplingInterval = 30 * time.Second
+// rollLogInterval is how often at most a given `from -> to` roll is logged at `warn`
+// level, see [Clients.logRoll].
+const rollLogInterval = 30 * time.Second
 
 type Clients[C any] struct {
 	clients               []C
@@ -26,13 +26,8 @@ type Clients[C any] struct {
 	lock                  sync.Mutex
 	logger                *zap.Logger
 
-	rollLogSamplingInterval time.Duration
-	rollLogs                map[string]*rollLogState
-}
-
-type rollLogState struct {
-	lastLoggedAt time.Time
-	suppressed   int
+	// rollLoggedAt is the last time a given `from -> to` roll was logged at `warn` level.
+	rollLoggedAt map[string]time.Time
 }
 
 func NewClients[C any](maxBlockFetchDuration time.Duration, rollingStrategy RollingStrategy[C], logger *zap.Logger) *Clients[C] {
@@ -45,8 +40,7 @@ func NewClients[C any](maxBlockFetchDuration time.Duration, rollingStrategy Roll
 		rollingStrategy:       rollingStrategy,
 		logger:                logger,
 
-		rollLogSamplingInterval: defaultRollLogSamplingInterval,
-		rollLogs:                map[string]*rollLogState{},
+		rollLoggedAt: map[string]time.Time{},
 	}
 }
 
@@ -122,47 +116,33 @@ func (c *Clients[C]) nameAt(index int) string {
 }
 
 // logRoll reports that we rolled from provider `from` to provider `to` because of
-// `err`. A given `from -> to` pair is logged at `warn` level at most once per
-// [Clients.rollLogSamplingInterval], the rolls suppressed in between being reported
-// as `suppressed_rolls` on the next logged one. Without this, a pool using
-// [RollingStrategyAlwaysUseFirst] whose first provider is down would emit one
-// warning on every single RPC call.
+// `err`. A given `from -> to` pair is logged at `warn` level again only once
+// [rollLogInterval] elapsed since the last time it was, the rolls in between going to
+// `debug` level. Without this, a pool using [RollingStrategyAlwaysUseFirst] whose
+// first provider is down would emit one warning on every single RPC call.
 func (c *Clients[C]) logRoll(from string, to string, err error) {
-	c.lock.Lock()
-
-	if c.rollLogs == nil {
-		c.rollLogs = map[string]*rollLogState{}
-	}
-
 	key := from + " -> " + to
-	state := c.rollLogs[key]
-	if state == nil {
-		state = &rollLogState{}
-		c.rollLogs[key] = state
+
+	c.lock.Lock()
+	if c.rollLoggedAt == nil {
+		c.rollLoggedAt = map[string]time.Time{}
 	}
 
 	now := time.Now()
-	if !state.lastLoggedAt.IsZero() && now.Sub(state.lastLoggedAt) < c.rollLogSamplingInterval {
-		state.suppressed++
-		c.lock.Unlock()
-
-		c.logger.Debug("rolling to next RPC provider",
-			zap.String("from_provider", from),
-			zap.String("to_provider", to),
-			zap.Error(err),
-		)
-		return
+	logIt := now.Sub(c.rollLoggedAt[key]) > rollLogInterval
+	if logIt {
+		c.rollLoggedAt[key] = now
 	}
-
-	suppressed := state.suppressed
-	state.suppressed = 0
-	state.lastLoggedAt = now
 	c.lock.Unlock()
 
-	c.logger.Warn("rolling to next RPC provider",
+	log := c.logger.Debug
+	if logIt {
+		log = c.logger.Warn
+	}
+
+	log("rolling to next RPC provider",
 		zap.String("from_provider", from),
 		zap.String("to_provider", to),
-		zap.Int("suppressed_rolls", suppressed),
 		zap.Error(err),
 	)
 }

--- a/rpc/clients.go
+++ b/rpc/clients.go
@@ -14,6 +14,10 @@ import (
 
 var ErrorNoMoreClient = errors.New("no more clients")
 
+// defaultRollLogSamplingInterval is how often at most a given `from -> to` roll is
+// logged at `warn` level, see [Clients.logRoll].
+const defaultRollLogSamplingInterval = 30 * time.Second
+
 type Clients[C any] struct {
 	clients               []C
 	names                 []string
@@ -21,6 +25,14 @@ type Clients[C any] struct {
 	rollingStrategy       RollingStrategy[C]
 	lock                  sync.Mutex
 	logger                *zap.Logger
+
+	rollLogSamplingInterval time.Duration
+	rollLogs                map[string]*rollLogState
+}
+
+type rollLogState struct {
+	lastLoggedAt time.Time
+	suppressed   int
 }
 
 func NewClients[C any](maxBlockFetchDuration time.Duration, rollingStrategy RollingStrategy[C], logger *zap.Logger) *Clients[C] {
@@ -32,6 +44,9 @@ func NewClients[C any](maxBlockFetchDuration time.Duration, rollingStrategy Roll
 		maxBlockFetchDuration: maxBlockFetchDuration,
 		rollingStrategy:       rollingStrategy,
 		logger:                logger,
+
+		rollLogSamplingInterval: defaultRollLogSamplingInterval,
+		rollLogs:                map[string]*rollLogState{},
 	}
 }
 
@@ -106,6 +121,52 @@ func (c *Clients[C]) nameAt(index int) string {
 	return c.names[index]
 }
 
+// logRoll reports that we rolled from provider `from` to provider `to` because of
+// `err`. A given `from -> to` pair is logged at `warn` level at most once per
+// [Clients.rollLogSamplingInterval], the rolls suppressed in between being reported
+// as `suppressed_rolls` on the next logged one. Without this, a pool using
+// [RollingStrategyAlwaysUseFirst] whose first provider is down would emit one
+// warning on every single RPC call.
+func (c *Clients[C]) logRoll(from string, to string, err error) {
+	c.lock.Lock()
+
+	if c.rollLogs == nil {
+		c.rollLogs = map[string]*rollLogState{}
+	}
+
+	key := from + " -> " + to
+	state := c.rollLogs[key]
+	if state == nil {
+		state = &rollLogState{}
+		c.rollLogs[key] = state
+	}
+
+	now := time.Now()
+	if !state.lastLoggedAt.IsZero() && now.Sub(state.lastLoggedAt) < c.rollLogSamplingInterval {
+		state.suppressed++
+		c.lock.Unlock()
+
+		c.logger.Debug("rolling to next RPC provider",
+			zap.String("from_provider", from),
+			zap.String("to_provider", to),
+			zap.Error(err),
+		)
+		return
+	}
+
+	suppressed := state.suppressed
+	state.suppressed = 0
+	state.lastLoggedAt = now
+	c.lock.Unlock()
+
+	c.logger.Warn("rolling to next RPC provider",
+		zap.String("from_provider", from),
+		zap.String("to_provider", to),
+		zap.Int("suppressed_rolls", suppressed),
+		zap.Error(err),
+	)
+}
+
 func WithClientsContext[C any, V any](clients *Clients[C], ctx context.Context, f func(context.Context, C) (v V, err error)) (v V, err error) {
 	var errs error
 
@@ -144,11 +205,7 @@ func WithClientsContext[C any, V any](clients *Clients[C], ctx context.Context, 
 				return v, errs
 			}
 
-			clients.logger.Warn("rolling to next RPC provider",
-				zap.String("from_provider", name),
-				zap.String("to_provider", nextName),
-				zap.Error(err),
-			)
+			clients.logRoll(name, nextName, err)
 
 			client, name = nextClient, nextName
 			continue

--- a/rpc/clients.go
+++ b/rpc/clients.go
@@ -3,6 +3,8 @@ package rpc
 import (
 	"context"
 	"errors"
+	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -14,6 +16,7 @@ var ErrorNoMoreClient = errors.New("no more clients")
 
 type Clients[C any] struct {
 	clients               []C
+	names                 []string
 	maxBlockFetchDuration time.Duration
 	rollingStrategy       RollingStrategy[C]
 	lock                  sync.Mutex
@@ -21,6 +24,10 @@ type Clients[C any] struct {
 }
 
 func NewClients[C any](maxBlockFetchDuration time.Duration, rollingStrategy RollingStrategy[C], logger *zap.Logger) *Clients[C] {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
 	return &Clients[C]{
 		maxBlockFetchDuration: maxBlockFetchDuration,
 		rollingStrategy:       rollingStrategy,
@@ -37,32 +44,79 @@ func (c *Clients[C]) StartSorting(ctx context.Context, direction SortDirection, 
 				c.logger.Warn("sorting", zap.Error(err))
 			}
 
-			switch s := c.rollingStrategy.(type) {
-			case *StickyRollingStrategy[C]:
-				s.firstCallToNewClient = true
-				s.usedClientCount = 0
-				s.nextClientIndex = 0
-			case *RollingStrategyAlwaysUseFirst[C]:
-				s.nextIndex = 0
-			}
+			c.Reset()
 
 			time.Sleep(every)
 		}
 	}()
 }
 
+// Add appends a client to the pool, giving it the auto-generated provider name
+// `client-<index>` where `<index>` is its position in the pool. Use [Clients.AddNamed]
+// to give the client a meaningful name, which is then reported in errors and logs.
 func (c *Clients[C]) Add(client C) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.clients = append(c.clients, client)
+
+	c.add(client, fmt.Sprintf("client-%d", len(c.clients)))
 }
+
+// AddNamed appends a client to the pool under the provider name `name`, which is
+// reported in errors and logs when this client is used and fails.
+func (c *Clients[C]) AddNamed(client C, name string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.add(client, name)
+}
+
+func (c *Clients[C]) add(client C, name string) {
+	c.clients = append(c.clients, client)
+	c.names = append(c.names, name)
+}
+
+// Names returns the provider names of all clients in the pool, in pool order (which
+// changes when the pool is sorted, see [Clients.StartSorting]).
+func (c *Clients[C]) Names() []string {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	return slices.Clone(c.names)
+}
+
+// Reset brings the rolling strategy back to the pool's declared order, so that the
+// next call to [WithClients]/[WithClientsContext] starts again from the first client
+// of the pool. It's the failback operation: a sticky strategy that rolled to a
+// fallback provider after a transient error would otherwise stay on that fallback
+// until the process restarts.
+func (c *Clients[C]) Reset() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.rollingStrategy.resetToDeclaredOrder()
+}
+
+// nameAt returns the provider name of the client at index `index`, the caller is
+// responsible of holding the lock.
+func (c *Clients[C]) nameAt(index int) string {
+	if index < 0 || index >= len(c.names) {
+		return fmt.Sprintf("client-%d", index)
+	}
+
+	return c.names[index]
+}
+
 func WithClientsContext[C any, V any](clients *Clients[C], ctx context.Context, f func(context.Context, C) (v V, err error)) (v V, err error) {
 	var errs error
 
 	// guard the rolling-strategy state (client selection), NOT the call to f
 	clients.lock.Lock()
 	clients.rollingStrategy.reset()
-	client, err := clients.rollingStrategy.next(clients)
+	client, index, err := clients.rollingStrategy.next(clients)
+	var name string
+	if err == nil {
+		name = clients.nameAt(index)
+	}
 	clients.lock.Unlock()
 	if err != nil {
 		errs = multierror.Append(errs, err)
@@ -76,15 +130,27 @@ func WithClientsContext[C any, V any](clients *Clients[C], ctx context.Context, 
 		cancel()
 
 		if err != nil {
-			errs = multierror.Append(errs, err)
+			errs = multierror.Append(errs, fmt.Errorf("provider %q: %w", name, err))
+
 			clients.lock.Lock()
-			client, err = clients.rollingStrategy.next(clients)
+			nextClient, nextIndex, nextErr := clients.rollingStrategy.next(clients)
+			var nextName string
+			if nextErr == nil {
+				nextName = clients.nameAt(nextIndex)
+			}
 			clients.lock.Unlock()
-			if err != nil {
-				errs = multierror.Append(errs, err)
+			if nextErr != nil {
+				errs = multierror.Append(errs, nextErr)
 				return v, errs
 			}
 
+			clients.logger.Warn("rolling to next RPC provider",
+				zap.String("from_provider", name),
+				zap.String("to_provider", nextName),
+				zap.Error(err),
+			)
+
+			client, name = nextClient, nextName
 			continue
 		}
 		return v, nil

--- a/rpc/clients_concurrent_test.go
+++ b/rpc/clients_concurrent_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"testing/synctest"
 	"time"
-
-	"go.uber.org/zap"
 )
 
 // TestWithClients_doesNotSerialize guards the fix in WithClientsContext: the
@@ -23,7 +21,7 @@ import (
 // never reaches an all-durably-blocked state, so the test hangs and fails.
 func TestWithClients_doesNotSerialize(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		clients := NewClients[any](time.Second, NewStickyRollingStrategy[any](), zap.NewNop())
+		clients := NewClients[any](time.Second, NewStickyRollingStrategy[any](), zlogTest)
 		for i := 0; i < 4; i++ {
 			clients.Add(new(any))
 		}
@@ -39,7 +37,7 @@ func TestWithClients_doesNotSerialize(t *testing.T) {
 				defer wg.Done()
 				_, _ = WithClients(clients, func(ctx context.Context, c any) (any, error) {
 					inside.Add(1) // record that we're inside f
-					<-release      // hold here until every caller is inside f
+					<-release     // hold here until every caller is inside f
 					return nil, nil
 				})
 			}()

--- a/rpc/clients_named_test.go
+++ b/rpc/clients_named_test.go
@@ -1,0 +1,152 @@
+package rpc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestClientsNames(t *testing.T) {
+	clients := NewClients(2*time.Second, NewStickyRollingStrategy[*rollClient](), zlogTest)
+	clients.Add(&rollClient{name: "c.1"})
+	clients.AddNamed(&rollClient{name: "c.2"}, "quicknode")
+	clients.Add(&rollClient{name: "c.3"})
+
+	assert.Equal(t, []string{"client-0", "quicknode", "client-2"}, clients.Names())
+}
+
+func TestClientsNamesSortedAlongClients(t *testing.T) {
+	clients := NewClients(2*time.Second, NewStickyRollingStrategy[*rollClient](), zlogTest)
+	clients.AddNamed(&rollClient{name: "c.1", sortValue: 100}, "primary")
+	clients.AddNamed(&rollClient{name: "c.2", sortValue: 101}, "fallback")
+
+	require.NoError(t, Sort(context.Background(), clients, &testSortFetcher{}, SortDirectionDescending))
+
+	assert.Equal(t, []string{"fallback", "primary"}, clients.Names())
+}
+
+func TestWithClientsErrorAttribution(t *testing.T) {
+	clients := NewClients(2*time.Second, NewStickyRollingStrategy[*rollClient](), zlogTest)
+	clients.AddNamed(&rollClient{name: "c.1"}, "primary")
+	clients.AddNamed(&rollClient{name: "c.2"}, "quicknode")
+
+	_, err := WithClients(clients, func(_ context.Context, client *rollClient) (any, error) {
+		return nil, fmt.Errorf("boom on %s", client.name)
+	})
+
+	require.ErrorIs(t, err, ErrorNoMoreClient)
+	assert.Contains(t, err.Error(), `provider "primary": boom on c.1`)
+	assert.Contains(t, err.Error(), `provider "quicknode": boom on c.2`)
+}
+
+func TestWithClientsErrorAttributionAutoNamed(t *testing.T) {
+	clients := NewClients(2*time.Second, NewRollingStrategyAlwaysUseFirst[*rollClient](), zlogTest)
+	clients.Add(&rollClient{name: "c.1"})
+	clients.Add(&rollClient{name: "c.2"})
+
+	_, err := WithClients(clients, func(_ context.Context, client *rollClient) (any, error) {
+		return nil, fmt.Errorf("boom on %s", client.name)
+	})
+
+	require.ErrorIs(t, err, ErrorNoMoreClient)
+	assert.Contains(t, err.Error(), `provider "client-0": boom on c.1`)
+	assert.Contains(t, err.Error(), `provider "client-1": boom on c.2`)
+}
+
+func TestWithClientsLogsRoll(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+
+	clients := NewClients(2*time.Second, NewStickyRollingStrategy[*rollClient](), zap.New(core))
+	clients.AddNamed(&rollClient{name: "c.1"}, "primary")
+	clients.AddNamed(&rollClient{name: "c.2"}, "quicknode")
+
+	_, err := WithClients(clients, func(_ context.Context, client *rollClient) (any, error) {
+		if client.name == "c.2" {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("next please")
+	})
+	require.NoError(t, err)
+
+	rolls := logs.FilterMessage("rolling to next RPC provider").All()
+	require.Len(t, rolls, 1)
+
+	fields := rolls[0].ContextMap()
+	assert.Equal(t, "primary", fields["from_provider"])
+	assert.Equal(t, "quicknode", fields["to_provider"])
+}
+
+// TestStickyRollingStrategyResetFailback ensures that a sticky strategy which rolled
+// to the fallback provider after a transient error goes back to the declared-order
+// primary once Clients.Reset is called.
+func TestStickyRollingStrategyResetFailback(t *testing.T) {
+	clients := NewClients(2*time.Second, NewStickyRollingStrategy[*rollClient](), zlogTest)
+	clients.AddNamed(&rollClient{name: "c.1"}, "primary")
+	clients.AddNamed(&rollClient{name: "c.2"}, "fallback")
+	clients.AddNamed(&rollClient{name: "c.3"}, "last-resort")
+
+	// Primary fails once, we roll to the fallback which answers.
+	names := firstProviderNames(t, clients, func(client *rollClient) error {
+		if client.name == "c.1" {
+			return fmt.Errorf("transient")
+		}
+		return nil
+	})
+	assert.Equal(t, []string{"c.1", "c.2"}, names)
+
+	// Sticky: without a reset we stay on the fallback, the primary is never retried.
+	names = firstProviderNames(t, clients, func(*rollClient) error { return nil })
+	assert.Equal(t, []string{"c.2"}, names)
+
+	clients.Reset()
+
+	// Failback: the declared-order primary is used again.
+	names = firstProviderNames(t, clients, func(*rollClient) error { return nil })
+	assert.Equal(t, []string{"c.1"}, names)
+}
+
+func TestRollingStrategyAlwaysUseFirstResetFailback(t *testing.T) {
+	clients := NewClients(2*time.Second, NewRollingStrategyAlwaysUseFirst[*rollClient](), zlogTest)
+	clients.AddNamed(&rollClient{name: "c.1"}, "primary")
+	clients.AddNamed(&rollClient{name: "c.2"}, "fallback")
+
+	// Roll away from the primary through the strategy directly, `WithClients` resets
+	// the strategy on entry so it would hide the failback we want to assert.
+	_, index, err := clients.rollingStrategy.next(clients)
+	require.NoError(t, err)
+	require.Equal(t, 0, index)
+
+	_, index, err = clients.rollingStrategy.next(clients)
+	require.NoError(t, err)
+	require.Equal(t, 1, index)
+
+	clients.Reset()
+
+	client, index, err := clients.rollingStrategy.next(clients)
+	require.NoError(t, err)
+	assert.Equal(t, 0, index)
+	assert.Equal(t, "c.1", client.name)
+}
+
+// firstProviderNames runs `f` through the clients pool, recording the name of each
+// client that was tried, in order.
+func firstProviderNames(t *testing.T, clients *Clients[*rollClient], f func(client *rollClient) error) []string {
+	t.Helper()
+
+	var tried []string
+	_, err := WithClients(clients, func(_ context.Context, client *rollClient) (any, error) {
+		tried = append(tried, client.name)
+		return nil, f(client)
+	})
+	require.NoError(t, err)
+
+	return tried
+}

--- a/rpc/clients_named_test.go
+++ b/rpc/clients_named_test.go
@@ -84,6 +84,87 @@ func TestWithClientsLogsRoll(t *testing.T) {
 	assert.Equal(t, "quicknode", fields["to_provider"])
 }
 
+// TestWithClientsRollLogIsSampled guards against log spam: a pool using
+// RollingStrategyAlwaysUseFirst whose first provider is down rolls on every single
+// call, we must not emit a warning each time.
+func TestWithClientsRollLogIsSampled(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+
+	clients := NewClients(2*time.Second, NewRollingStrategyAlwaysUseFirst[*rollClient](), zap.New(core))
+	clients.AddNamed(&rollClient{name: "c.1"}, "primary")
+	clients.AddNamed(&rollClient{name: "c.2"}, "quicknode")
+
+	downPrimary := func(_ context.Context, client *rollClient) (any, error) {
+		if client.name == "c.1" {
+			return nil, fmt.Errorf("connection refused")
+		}
+
+		return nil, nil
+	}
+
+	for range 5 {
+		_, err := WithClients(clients, downPrimary)
+		require.NoError(t, err)
+	}
+
+	rolls := logs.FilterMessage("rolling to next RPC provider").All()
+	warns := filterLevel(rolls, zapcore.WarnLevel)
+	require.Len(t, warns, 1, "the 5 rolls of the same primary -> fallback pair must be sampled down to a single warning")
+	assert.Equal(t, int64(0), warns[0].ContextMap()["suppressed_rolls"])
+
+	// The suppressed ones are still there at debug level for whoever wants them.
+	assert.Len(t, filterLevel(rolls, zapcore.DebugLevel), 4)
+
+	// Once the sampling window elapsed, we log again and report what was suppressed.
+	clients.rollLogSamplingInterval = 0
+
+	_, err := WithClients(clients, downPrimary)
+	require.NoError(t, err)
+
+	warns = filterLevel(logs.FilterMessage("rolling to next RPC provider").All(), zapcore.WarnLevel)
+	require.Len(t, warns, 2)
+	assert.Equal(t, int64(4), warns[1].ContextMap()["suppressed_rolls"])
+}
+
+// TestWithClientsRollLogPerProviderPair ensures the sampling is per `from -> to`
+// pair, rolling to a different provider must not be swallowed by an earlier roll.
+func TestWithClientsRollLogPerProviderPair(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+
+	clients := NewClients(2*time.Second, NewRollingStrategyAlwaysUseFirst[*rollClient](), zap.New(core))
+	clients.AddNamed(&rollClient{name: "c.1"}, "primary")
+	clients.AddNamed(&rollClient{name: "c.2"}, "quicknode")
+	clients.AddNamed(&rollClient{name: "c.3"}, "last-resort")
+
+	_, err := WithClients(clients, func(_ context.Context, client *rollClient) (any, error) {
+		if client.name == "c.3" {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("boom")
+	})
+	require.NoError(t, err)
+
+	var pairs [][2]string
+	for _, roll := range logs.FilterMessage("rolling to next RPC provider").All() {
+		fields := roll.ContextMap()
+		pairs = append(pairs, [2]string{fields["from_provider"].(string), fields["to_provider"].(string)})
+	}
+
+	assert.Equal(t, [][2]string{{"primary", "quicknode"}, {"quicknode", "last-resort"}}, pairs)
+}
+
+func filterLevel(entries []observer.LoggedEntry, level zapcore.Level) []observer.LoggedEntry {
+	var out []observer.LoggedEntry
+	for _, entry := range entries {
+		if entry.Level == level {
+			out = append(out, entry)
+		}
+	}
+
+	return out
+}
+
 // TestStickyRollingStrategyResetFailback ensures that a sticky strategy which rolled
 // to the fallback provider after a transient error goes back to the declared-order
 // primary once Clients.Reset is called.

--- a/rpc/clients_named_test.go
+++ b/rpc/clients_named_test.go
@@ -108,22 +108,19 @@ func TestWithClientsRollLogIsSampled(t *testing.T) {
 	}
 
 	rolls := logs.FilterMessage("rolling to next RPC provider").All()
-	warns := filterLevel(rolls, zapcore.WarnLevel)
-	require.Len(t, warns, 1, "the 5 rolls of the same primary -> fallback pair must be sampled down to a single warning")
-	assert.Equal(t, int64(0), warns[0].ContextMap()["suppressed_rolls"])
+	require.Len(t, filterLevel(rolls, zapcore.WarnLevel), 1, "the 5 rolls of the same primary -> fallback pair must be sampled down to a single warning")
 
-	// The suppressed ones are still there at debug level for whoever wants them.
+	// The sampled out ones are still there at debug level for whoever wants them.
 	assert.Len(t, filterLevel(rolls, zapcore.DebugLevel), 4)
 
-	// Once the sampling window elapsed, we log again and report what was suppressed.
-	clients.rollLogSamplingInterval = 0
+	// Once `rollLogInterval` elapsed, the roll warns again.
+	clients.rollLoggedAt["primary -> quicknode"] = time.Now().Add(-rollLogInterval - time.Second)
 
 	_, err := WithClients(clients, downPrimary)
 	require.NoError(t, err)
 
-	warns = filterLevel(logs.FilterMessage("rolling to next RPC provider").All(), zapcore.WarnLevel)
-	require.Len(t, warns, 2)
-	assert.Equal(t, int64(4), warns[1].ContextMap()["suppressed_rolls"])
+	warns := filterLevel(logs.FilterMessage("rolling to next RPC provider").All(), zapcore.WarnLevel)
+	assert.Len(t, warns, 2)
 }
 
 // TestWithClientsRollLogPerProviderPair ensures the sampling is per `from -> to`

--- a/rpc/log_test.go
+++ b/rpc/log_test.go
@@ -1,0 +1,9 @@
+package rpc
+
+import "github.com/streamingfast/logging"
+
+var zlogTest, _ = logging.PackageLogger("rpc-test", "github.com/streamingfast/firehose-core/rpc.test")
+
+func init() {
+	logging.InstantiateLoggers()
+}

--- a/rpc/rolling_strategy.go
+++ b/rpc/rolling_strategy.go
@@ -64,12 +64,6 @@ func (s *StickyRollingStrategy[C]) next(clients *Clients[C]) (client C, index in
 		return client, index, nil
 	}
 
-	if s.nextClientIndex == len(clients.clients) { //roll to 1st client
-		client = clients.clients[0]
-		s.usedClientCount = s.usedClientCount + 1
-		return client, 0, nil
-	}
-
 	index = s.nextClientIndex
 	client = clients.clients[index]
 	s.usedClientCount = s.usedClientCount + 1

--- a/rpc/rolling_strategy.go
+++ b/rpc/rolling_strategy.go
@@ -1,8 +1,19 @@
 package rpc
 
 type RollingStrategy[C any] interface {
+	// reset prepares the strategy for a new [WithClientsContext] call, it does **not**
+	// change which client is going to be returned first, use [resetToDeclaredOrder] for
+	// that.
 	reset()
-	next(clients *Clients[C]) (C, error)
+
+	// resetToDeclaredOrder brings the strategy back to its initial state so that the next
+	// call to [next] returns the first client of the pool, in declared (or last sorted)
+	// order. It's the "failback" operation, exposed publicly through [Clients.Reset].
+	resetToDeclaredOrder()
+
+	// next returns the client to use next, alongside its index in the pool so that the
+	// caller can resolve the client's provider name.
+	next(clients *Clients[C]) (C, int, error)
 }
 
 type StickyRollingStrategy[C any] struct {
@@ -21,9 +32,15 @@ func (s *StickyRollingStrategy[C]) reset() {
 	s.usedClientCount = 0
 }
 
-func (s *StickyRollingStrategy[C]) next(clients *Clients[C]) (client C, err error) {
+func (s *StickyRollingStrategy[C]) resetToDeclaredOrder() {
+	s.firstCallToNewClient = true
+	s.usedClientCount = 0
+	s.nextClientIndex = 0
+}
+
+func (s *StickyRollingStrategy[C]) next(clients *Clients[C]) (client C, index int, err error) {
 	if len(clients.clients) == s.usedClientCount {
-		return client, ErrorNoMoreClient
+		return client, 0, ErrorNoMoreClient
 	}
 
 	if s.firstCallToNewClient {
@@ -31,7 +48,7 @@ func (s *StickyRollingStrategy[C]) next(clients *Clients[C]) (client C, err erro
 		client = clients.clients[0]
 		s.usedClientCount = s.usedClientCount + 1
 		s.nextClientIndex = s.nextClientIndex + 1
-		return client, nil
+		return client, 0, nil
 	}
 
 	if s.nextClientIndex == len(clients.clients) { //roll to 1st client
@@ -40,22 +57,24 @@ func (s *StickyRollingStrategy[C]) next(clients *Clients[C]) (client C, err erro
 
 	if s.usedClientCount == 0 { //just been reset
 		s.nextClientIndex = s.prevIndex(clients)
-		client = clients.clients[s.nextClientIndex]
+		index = s.nextClientIndex
+		client = clients.clients[index]
 		s.usedClientCount = s.usedClientCount + 1
 		s.nextClientIndex = s.nextClientIndex + 1
-		return client, nil
+		return client, index, nil
 	}
 
 	if s.nextClientIndex == len(clients.clients) { //roll to 1st client
 		client = clients.clients[0]
 		s.usedClientCount = s.usedClientCount + 1
-		return client, nil
+		return client, 0, nil
 	}
 
-	client = clients.clients[s.nextClientIndex]
+	index = s.nextClientIndex
+	client = clients.clients[index]
 	s.usedClientCount = s.usedClientCount + 1
 	s.nextClientIndex = s.nextClientIndex + 1
-	return client, nil
+	return client, index, nil
 }
 
 func (s *StickyRollingStrategy[C]) prevIndex(clients *Clients[C]) int {
@@ -77,13 +96,17 @@ func (s *RollingStrategyAlwaysUseFirst[C]) reset() {
 	s.nextIndex = 0
 }
 
-func (s *RollingStrategyAlwaysUseFirst[C]) next(c *Clients[C]) (client C, err error) {
+func (s *RollingStrategyAlwaysUseFirst[C]) resetToDeclaredOrder() {
+	s.nextIndex = 0
+}
 
+func (s *RollingStrategyAlwaysUseFirst[C]) next(c *Clients[C]) (client C, index int, err error) {
 	if len(c.clients) <= s.nextIndex {
-		return client, ErrorNoMoreClient
+		return client, 0, ErrorNoMoreClient
 	}
-	client = c.clients[s.nextIndex]
-	s.nextIndex++
-	return client, nil
 
+	index = s.nextIndex
+	client = c.clients[index]
+	s.nextIndex++
+	return client, index, nil
 }

--- a/rpc/rolling_strategy_test.go
+++ b/rpc/rolling_strategy_test.go
@@ -13,6 +13,7 @@ type rollClient struct {
 	callCount int
 	name      string
 	sortValue uint64
+	pool      *Clients[*rollClient] // only set by tests that reach back into the pool
 }
 
 func (r *rollClient) fetchSortValue(_ context.Context) (sortValue uint64, err error) {

--- a/rpc/rolling_strategy_test.go
+++ b/rpc/rolling_strategy_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,7 +24,7 @@ func TestStickyRollingStrategy(t *testing.T) {
 	rollingStrategy := NewStickyRollingStrategy[*rollClient]()
 	rollingStrategy.reset()
 
-	clients := NewClients(2*time.Second, rollingStrategy, zap.NewNop())
+	clients := NewClients(2*time.Second, rollingStrategy, zlogTest)
 	clients.Add(&rollClient{name: "c.1"})
 	clients.Add(&rollClient{name: "c.2"})
 	clients.Add(&rollClient{name: "c.3"})

--- a/rpc/sort.go
+++ b/rpc/sort.go
@@ -40,13 +40,16 @@ func Sort[C any](ctx context.Context, clients *Clients[C], sortValueFetch SortVa
 	})
 
 	var sorted []C
+	var sortedNames []string
 	for _, v := range sortableValues {
 		sorted = append(sorted, clients.clients[v.clientIndex])
+		sortedNames = append(sortedNames, clients.nameAt(v.clientIndex))
 	}
 
 	clients.lock.Lock()
 	defer clients.lock.Unlock()
 	clients.clients = sorted
+	clients.names = sortedNames
 
 	return nil
 }

--- a/rpc/sort.go
+++ b/rpc/sort.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"slices"
 	"sort"
 )
 
@@ -21,35 +22,63 @@ func Sort[C any](ctx context.Context, clients *Clients[C], sortValueFetch SortVa
 		clientIndex int
 		sortValue   uint64
 	}
-	var sortableValues []sortable
-	for i, client := range clients.clients {
-		var v uint64
-		var err error
-		v, err = sortValueFetch.FetchSortValue(ctx, client)
-		if err != nil {
-			//do nothing
+
+	for {
+		// Sort a snapshot rather than the pool itself: `FetchSortValue` below is a network
+		// call per client, and holding the lock across them would block every
+		// `WithClientsContext` for the whole round, so one hung provider would wedge the
+		// entire pool (`StartSorting` gets no timeout, it's handed the app's context).
+		clients.lock.Lock()
+		pool := slices.Clone(clients.clients)
+		names := slices.Clone(clients.names)
+		clients.lock.Unlock()
+
+		var sortableValues []sortable
+		for i, client := range pool {
+			var v uint64
+			var err error
+			v, err = sortValueFetch.FetchSortValue(ctx, client)
+			if err != nil {
+				//do nothing
+			}
+			sortableValues = append(sortableValues, sortable{i, v})
 		}
-		sortableValues = append(sortableValues, sortable{i, v})
-	}
 
-	sort.Slice(sortableValues, func(i, j int) bool {
-		if direction == SortDirectionAscending {
-			return sortableValues[i].sortValue < sortableValues[j].sortValue
+		sort.Slice(sortableValues, func(i, j int) bool {
+			if direction == SortDirectionAscending {
+				return sortableValues[i].sortValue < sortableValues[j].sortValue
+			}
+			return sortableValues[i].sortValue > sortableValues[j].sortValue
+		})
+
+		var sorted []C
+		var sortedNames []string
+		for _, v := range sortableValues {
+			sorted = append(sorted, pool[v.clientIndex])
+			sortedNames = append(sortedNames, names[v.clientIndex])
 		}
-		return sortableValues[i].sortValue > sortableValues[j].sortValue
-	})
 
-	var sorted []C
-	var sortedNames []string
-	for _, v := range sortableValues {
-		sorted = append(sorted, clients.clients[v.clientIndex])
-		sortedNames = append(sortedNames, clients.nameAt(v.clientIndex))
+		// The pool only ever grows through `Add`/`AddNamed` or gets permuted by this very
+		// function, so a length that still matches the snapshot means no client was added
+		// while we were fetching and `sorted` covers the whole pool. A concurrent `Sort`
+		// that published in between keeps the length, so the loser only overwrites the
+		// order, never the set, and the next round settles it.
+		clients.lock.Lock()
+		published := len(clients.clients) == len(pool)
+		if published {
+			clients.clients = sorted
+			clients.names = sortedNames
+		}
+		clients.lock.Unlock()
+
+		if published {
+			return nil
+		}
+
+		// A client was added mid-round and has no sort value yet, so publishing would drop
+		// it from the pool. Redo the round with it included.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 	}
-
-	clients.lock.Lock()
-	defer clients.lock.Unlock()
-	clients.clients = sorted
-	clients.names = sortedNames
-
-	return nil
 }

--- a/rpc/sort_concurrent_test.go
+++ b/rpc/sort_concurrent_test.go
@@ -1,0 +1,145 @@
+package rpc
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSortConcurrentWithPoolAccess is a race-detector regression test: Sort used to
+// read clients.clients and clients.names without holding the lock, while StartSorting
+// ran it on its own goroutine against a pool that AddNamed and WithClientsContext
+// mutate under it.
+func TestSortConcurrentWithPoolAccess(t *testing.T) {
+	clients := NewClients(2*time.Second, NewStickyRollingStrategy[*rollClient](), zlogTest)
+	for i := 0; i < 4; i++ {
+		clients.AddNamed(&rollClient{name: fmt.Sprintf("c.%d", i), sortValue: uint64(i)}, fmt.Sprintf("p.%d", i))
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				require.NoError(t, Sort(context.Background(), clients, &testSortFetcher{}, SortDirectionDescending))
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for j := 0; j < 50; j++ {
+			_ = clients.Names()
+			_, _ = WithClients(clients, func(context.Context, *rollClient) (any, error) { return nil, nil })
+		}
+	}()
+
+	wg.Wait()
+
+	assert.Len(t, clients.Names(), 4)
+}
+
+func clientNames(clients *Clients[*rollClient]) []string {
+	clients.lock.Lock()
+	defer clients.lock.Unlock()
+
+	var names []string
+	for _, client := range clients.clients {
+		names = append(names, client.name)
+	}
+
+	return names
+}
+
+// addingSortFetcher appends a client to the pool from inside FetchSortValue, once, so
+// that it lands while Sort is between its snapshot and its publication.
+type addingSortFetcher struct {
+	once   sync.Once
+	rounds int
+	add    func()
+}
+
+func (f *addingSortFetcher) FetchSortValue(_ context.Context, client *rollClient) (uint64, error) {
+	f.once.Do(func() { f.rounds++; f.add() })
+	return client.sortValue, nil
+}
+
+// TestSortKeepsClientAddedMidRound guards the read-modify-write gap in Sort: it
+// snapshots the pool, fetches a sort value per client over the network, then writes
+// the pool back. A client added during that gap used to be silently overwritten out of
+// existence by the write.
+func TestSortKeepsClientAddedMidRound(t *testing.T) {
+	clients := NewClients(2*time.Second, NewStickyRollingStrategy[*rollClient](), zlogTest)
+	clients.AddNamed(&rollClient{name: "c.1", sortValue: 100}, "primary")
+	clients.AddNamed(&rollClient{name: "c.2", sortValue: 101}, "fallback")
+
+	fetcher := &addingSortFetcher{add: func() {
+		clients.AddNamed(&rollClient{name: "c.3", sortValue: 102}, "late-arrival")
+	}}
+
+	require.NoError(t, Sort(context.Background(), clients, fetcher, SortDirectionDescending))
+
+	// The round that raced the Add is discarded and redone, so the late client is not
+	// merely kept, it is sorted along with the rest.
+	assert.Equal(t, []string{"c.3", "c.2", "c.1"}, clientNames(clients))
+	assert.Equal(t, []string{"late-arrival", "fallback", "primary"}, clients.Names())
+}
+
+// TestSortStopsRetryingOnCancelledContext ensures the retry above cannot spin forever
+// once the app is shutting down.
+func TestSortStopsRetryingOnCancelledContext(t *testing.T) {
+	clients := NewClients(2*time.Second, NewStickyRollingStrategy[*rollClient](), zlogTest)
+	clients.Add(&rollClient{name: "c.1", sortValue: 100})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	fetcher := &addingSortFetcher{add: func() {
+		clients.Add(&rollClient{name: "c.2", sortValue: 101})
+		cancel()
+	}}
+
+	require.ErrorIs(t, Sort(ctx, clients, fetcher, SortDirectionDescending), context.Canceled)
+}
+
+// reentrantSortFetcher reads the pool back from inside FetchSortValue, once.
+type reentrantSortFetcher struct {
+	once  sync.Once
+	names []string
+}
+
+func (f *reentrantSortFetcher) FetchSortValue(_ context.Context, client *rollClient) (uint64, error) {
+	f.once.Do(func() { f.names = client.pool.Names() })
+	return client.sortValue, nil
+}
+
+// TestSortDoesNotHoldLockDuringFetch guards against the tempting fix to the race
+// above, wrapping all of Sort in the lock. FetchSortValue does a network call per
+// client and Sort is handed the app context with no timeout, so holding the lock
+// across the loop lets one hung provider wedge every WithClientsContext in the pool.
+func TestSortDoesNotHoldLockDuringFetch(t *testing.T) {
+	clients := NewClients(2*time.Second, NewStickyRollingStrategy[*rollClient](), zlogTest)
+	clients.Add(&rollClient{name: "c.1", sortValue: 100, pool: clients})
+
+	fetcher := &reentrantSortFetcher{}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Sort(context.Background(), clients, fetcher, SortDirectionDescending)
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Sort is holding clients.lock across FetchSortValue")
+	}
+
+	assert.Equal(t, []string{"client-0"}, fetcher.names)
+}

--- a/rpc/sort_test.go
+++ b/rpc/sort_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,7 +19,7 @@ func TestClientsSort(t *testing.T) {
 	rollingStrategy := NewStickyRollingStrategy[*rollClient]()
 	rollingStrategy.reset()
 
-	clients := NewClients(2*time.Second, rollingStrategy, zap.NewNop())
+	clients := NewClients(2*time.Second, rollingStrategy, zlogTest)
 	clients.Add(&rollClient{name: "c.1", sortValue: 100})
 	clients.Add(&rollClient{name: "c.2", sortValue: 101})
 	clients.Add(&rollClient{name: "c.3", sortValue: 102})


### PR DESCRIPTION
## Why

sf-operator is adding a QuickNode fallback RPC provider to the `aval-mainnet` Firehose reader, which runs `fireeth tools poller optimism <rpc-endpoint> <first-streamable-block>`. firehose-ethereum is getting a repeatable `--provider=<url>#<name>` flag in a sibling change; this is the firehose-core side that makes provider names usable at failure time.

Two gaps in the current pool:

1. `Clients[C]` stored only `clients []C`. `eth-go`'s `rpc.Client` keeps its endpoint unexported with no accessor, so once a client is in the pool nothing could say which provider it is — `WithClientsContext` appended every attempt error with no attribution.
2. `StickyRollingStrategy` was sticky forever. `reset()` only zeroed `usedClientCount` and `next()` then returned `prevIndex()`, i.e. the last client used. A single transient error on the primary moved the caller to the fallback permanently until process restart. The only escape was `StartSorting`, whose goroutine reset the strategy through an inline type switch — bundled with sorting, so callers that don't want sorting couldn't get the reset.

## What changed

New public API on `rpc.Clients`:

```go
func (c *Clients[C]) Add(client C)                    // unchanged behavior; auto-names "client-<idx>"
func (c *Clients[C]) AddNamed(client C, name string)  // new
func (c *Clients[C]) Names() []string                 // new, in pool order
func (c *Clients[C]) Reset()                          // new: re-prefer declared order
```

- `Clients` tracks a provider name per client. `Add` keeps working unchanged for the existing callers across the chain repos and auto-names the client `client-<index>`. `Sort` reorders the names alongside the clients so `Names()` stays truthful after a sort.
- `Reset()` brings the rolling strategy back to the pool's declared order — the failback operation. The reset now lives behind the `RollingStrategy` interface as `resetToDeclaredOrder()`, so the type switch in `StartSorting` is gone and `StartSorting` calls `Reset()`.
- `RollingStrategy.next` returns `(C, int, error)` so `Clients` can resolve the selected client's name. The interface's methods are unexported, so it can only be implemented inside the package — not a breaking change for external callers.
- `WithClientsContext` wraps each failed attempt as `fmt.Errorf("provider %q: %w", name, err)` before appending to the multierror, and logs each roll at `warn` level with `from_provider`/`to_provider` so a failover is visible in logs without waiting for the final error. A given `from -> to` roll is logged at `warn` at most once every 30s (review feedback): a pool using `RollingStrategyAlwaysUseFirst` rolls on every call, so a permanently down first provider would otherwise warn once per RPC call. The rolls in between go to `debug` and are counted as `suppressed_rolls` on the next warning.
- `NewClients` tolerates a nil logger.

No metrics counter: the `rpc` package has no metrics registry and wiring one in would mean new dependencies and plumbing, so it was skipped rather than invented.

## Tests

New coverage in `rpc/clients_named_test.go`: named vs auto-named clients, names surviving a sort, error attribution text for both naming modes, the roll log's from/to fields, the roll-log sampling (per `from -> to` pair, with the suppressed count), and the failback case — that `Reset()` sends the next call back to the declared-order primary — for both strategies. Test loggers follow the `logging.PackageLogger` pattern (new `rpc/log_test.go`), and the existing `rpc` tests were moved off `zap.NewNop()`.

`./rpc/...` and `./blockpoller/...` pass, `go build ./...` is clean. `relayer/TestRelayerReconnectsAfterSourceRestart` fails, but it fails on a clean `develop` checkout too and is unrelated to this change.

## Follow-up

The sibling firehose-ethereum change needs a firehose-core release to `go get`; the entries here sit under a new `## Unreleased` CHANGELOG section (latest tag is `v1.16.1`, this is additive so `v1.17.0`).
