### PR TITLE
rpc: sort a snapshot of the clients pool under lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 - `rpc.WithClients`/`rpc.WithClientsContext` now attribute each failed attempt to its provider, the returned error reads `provider "<name>": <error>`, and each roll to another provider is logged at `warn` level with the `from_provider`/`to_provider` names.
 
+### Fixed
+
+- `rpc.Sort` no longer reads the clients pool without holding the lock, which was a data race against `Add`/`AddNamed` and against the client selection in `WithClientsContext`, since `StartSorting` runs `Sort` on its own goroutine. It now sorts a snapshot taken under the lock, keeping the per-client network fetches lock-free.
+
+- A client added to the pool while `rpc.Sort` was running is no longer dropped. `Sort` snapshots the pool, fetches a sort value per client over the network, then writes the pool back, and that write used to overwrite anything appended in between. It now redoes the round instead of publishing, so the new client is sorted along with the rest.
+
 ## v1.16.1
 
 ### Added

--- a/rpc/rolling_strategy_test.go
+++ b/rpc/rolling_strategy_test.go
@@ -13,6 +13,7 @@ type rollClient struct {
 	callCount int
 	name      string
 	sortValue uint64
+	pool      *Clients[*rollClient] // only set by tests that reach back into the pool
 }
 
 func (r *rollClient) fetchSortValue(_ context.Context) (sortValue uint64, err error) {

--- a/rpc/sort.go
+++ b/rpc/sort.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"slices"
 	"sort"
 )
 
@@ -21,35 +22,63 @@ func Sort[C any](ctx context.Context, clients *Clients[C], sortValueFetch SortVa
 		clientIndex int
 		sortValue   uint64
 	}
-	var sortableValues []sortable
-	for i, client := range clients.clients {
-		var v uint64
-		var err error
-		v, err = sortValueFetch.FetchSortValue(ctx, client)
-		if err != nil {
-			//do nothing
+
+	for {
+		// Sort a snapshot rather than the pool itself: `FetchSortValue` below is a network
+		// call per client, and holding the lock across them would block every
+		// `WithClientsContext` for the whole round, so one hung provider would wedge the
+		// entire pool (`StartSorting` gets no timeout, it's handed the app's context).
+		clients.lock.Lock()
+		pool := slices.Clone(clients.clients)
+		names := slices.Clone(clients.names)
+		clients.lock.Unlock()
+
+		var sortableValues []sortable
+		for i, client := range pool {
+			var v uint64
+			var err error
+			v, err = sortValueFetch.FetchSortValue(ctx, client)
+			if err != nil {
+				//do nothing
+			}
+			sortableValues = append(sortableValues, sortable{i, v})
 		}
-		sortableValues = append(sortableValues, sortable{i, v})
-	}
 
-	sort.Slice(sortableValues, func(i, j int) bool {
-		if direction == SortDirectionAscending {
-			return sortableValues[i].sortValue < sortableValues[j].sortValue
+		sort.Slice(sortableValues, func(i, j int) bool {
+			if direction == SortDirectionAscending {
+				return sortableValues[i].sortValue < sortableValues[j].sortValue
+			}
+			return sortableValues[i].sortValue > sortableValues[j].sortValue
+		})
+
+		var sorted []C
+		var sortedNames []string
+		for _, v := range sortableValues {
+			sorted = append(sorted, pool[v.clientIndex])
+			sortedNames = append(sortedNames, names[v.clientIndex])
 		}
-		return sortableValues[i].sortValue > sortableValues[j].sortValue
-	})
 
-	var sorted []C
-	var sortedNames []string
-	for _, v := range sortableValues {
-		sorted = append(sorted, clients.clients[v.clientIndex])
-		sortedNames = append(sortedNames, clients.nameAt(v.clientIndex))
+		// The pool only ever grows through `Add`/`AddNamed` or gets permuted by this very
+		// function, so a length that still matches the snapshot means no client was added
+		// while we were fetching and `sorted` covers the whole pool. A concurrent `Sort`
+		// that published in between keeps the length, so the loser only overwrites the
+		// order, never the set, and the next round settles it.
+		clients.lock.Lock()
+		published := len(clients.clients) == len(pool)
+		if published {
+			clients.clients = sorted
+			clients.names = sortedNames
+		}
+		clients.lock.Unlock()
+
+		if published {
+			return nil
+		}
+
+		// A client was added mid-round and has no sort value yet, so publishing would drop
+		// it from the pool. Redo the round with it included.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 	}
-
-	clients.lock.Lock()
-	defer clients.lock.Unlock()
-	clients.clients = sorted
-	clients.names = sortedNames
-
-	return nil
 }

--- a/rpc/sort_concurrent_test.go
+++ b/rpc/sort_concurrent_test.go
@@ -1,0 +1,145 @@
+package rpc
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSortConcurrentWithPoolAccess is a race-detector regression test: Sort used to
+// read clients.clients and clients.names without holding the lock, while StartSorting
+// ran it on its own goroutine against a pool that AddNamed and WithClientsContext
+// mutate under it.
+func TestSortConcurrentWithPoolAccess(t *testing.T) {
+	clients := NewClients(2*time.Second, NewStickyRollingStrategy[*rollClient](), zlogTest)
+	for i := 0; i < 4; i++ {
+		clients.AddNamed(&rollClient{name: fmt.Sprintf("c.%d", i), sortValue: uint64(i)}, fmt.Sprintf("p.%d", i))
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				require.NoError(t, Sort(context.Background(), clients, &testSortFetcher{}, SortDirectionDescending))
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for j := 0; j < 50; j++ {
+			_ = clients.Names()
+			_, _ = WithClients(clients, func(context.Context, *rollClient) (any, error) { return nil, nil })
+		}
+	}()
+
+	wg.Wait()
+
+	assert.Len(t, clients.Names(), 4)
+}
+
+func clientNames(clients *Clients[*rollClient]) []string {
+	clients.lock.Lock()
+	defer clients.lock.Unlock()
+
+	var names []string
+	for _, client := range clients.clients {
+		names = append(names, client.name)
+	}
+
+	return names
+}
+
+// addingSortFetcher appends a client to the pool from inside FetchSortValue, once, so
+// that it lands while Sort is between its snapshot and its publication.
+type addingSortFetcher struct {
+	once   sync.Once
+	rounds int
+	add    func()
+}
+
+func (f *addingSortFetcher) FetchSortValue(_ context.Context, client *rollClient) (uint64, error) {
+	f.once.Do(func() { f.rounds++; f.add() })
+	return client.sortValue, nil
+}
+
+// TestSortKeepsClientAddedMidRound guards the read-modify-write gap in Sort: it
+// snapshots the pool, fetches a sort value per client over the network, then writes
+// the pool back. A client added during that gap used to be silently overwritten out of
+// existence by the write.
+func TestSortKeepsClientAddedMidRound(t *testing.T) {
+	clients := NewClients(2*time.Second, NewStickyRollingStrategy[*rollClient](), zlogTest)
+	clients.AddNamed(&rollClient{name: "c.1", sortValue: 100}, "primary")
+	clients.AddNamed(&rollClient{name: "c.2", sortValue: 101}, "fallback")
+
+	fetcher := &addingSortFetcher{add: func() {
+		clients.AddNamed(&rollClient{name: "c.3", sortValue: 102}, "late-arrival")
+	}}
+
+	require.NoError(t, Sort(context.Background(), clients, fetcher, SortDirectionDescending))
+
+	// The round that raced the Add is discarded and redone, so the late client is not
+	// merely kept, it is sorted along with the rest.
+	assert.Equal(t, []string{"c.3", "c.2", "c.1"}, clientNames(clients))
+	assert.Equal(t, []string{"late-arrival", "fallback", "primary"}, clients.Names())
+}
+
+// TestSortStopsRetryingOnCancelledContext ensures the retry above cannot spin forever
+// once the app is shutting down.
+func TestSortStopsRetryingOnCancelledContext(t *testing.T) {
+	clients := NewClients(2*time.Second, NewStickyRollingStrategy[*rollClient](), zlogTest)
+	clients.Add(&rollClient{name: "c.1", sortValue: 100})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	fetcher := &addingSortFetcher{add: func() {
+		clients.Add(&rollClient{name: "c.2", sortValue: 101})
+		cancel()
+	}}
+
+	require.ErrorIs(t, Sort(ctx, clients, fetcher, SortDirectionDescending), context.Canceled)
+}
+
+// reentrantSortFetcher reads the pool back from inside FetchSortValue, once.
+type reentrantSortFetcher struct {
+	once  sync.Once
+	names []string
+}
+
+func (f *reentrantSortFetcher) FetchSortValue(_ context.Context, client *rollClient) (uint64, error) {
+	f.once.Do(func() { f.names = client.pool.Names() })
+	return client.sortValue, nil
+}
+
+// TestSortDoesNotHoldLockDuringFetch guards against the tempting fix to the race
+// above, wrapping all of Sort in the lock. FetchSortValue does a network call per
+// client and Sort is handed the app context with no timeout, so holding the lock
+// across the loop lets one hung provider wedge every WithClientsContext in the pool.
+func TestSortDoesNotHoldLockDuringFetch(t *testing.T) {
+	clients := NewClients(2*time.Second, NewStickyRollingStrategy[*rollClient](), zlogTest)
+	clients.Add(&rollClient{name: "c.1", sortValue: 100, pool: clients})
+
+	fetcher := &reentrantSortFetcher{}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Sort(context.Background(), clients, fetcher, SortDirectionDescending)
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Sort is holding clients.lock across FetchSortValue")
+	}
+
+	assert.Equal(t, []string{"client-0"}, fetcher.names)
+}


### PR DESCRIPTION
Targets `feature/rpc-clients-named-providers` (#198), not `develop`.

## Why

Two problems in `Sort`, one of which #198 makes worse.

**1. Data race.** `Sort` reads `clients.clients` — and, since #198, `clients.names` via `nameAt` — without holding `clients.lock`; the lock is only taken for the final two assignments. `StartSorting` runs `Sort` on its own goroutine, concurrently with `Add`/`AddNamed` and with the client selection in `WithClientsContext`. `append` in `Add` can reallocate the backing array and rewrite the slice header while `Sort` reads it, with no happens-before edge. #198 adds a second racing read on the new `names` slice, and does it through `nameAt`, whose own doc comment says *"the caller is responsible of holding the lock"*.

**2. Lost writes.** `Sort` is a read-modify-write across a gap that spans one network call per client. A client added during that gap is silently overwritten out of existence by the final assignment.

## Why not just take the lock for the whole function

Because `Sort` has no timeout. `firehose-solana/cmd/firesol/rpc/fetcher.go:76` — the only production caller of `StartSorting` — passes `cmd.Context()`, the root context, and `Sort` never applies `maxBlockFetchDuration`. `FetchSortValue` is one network round-trip per client, run sequentially.

Holding the lock across that loop means every `WithClientsContext` blocks for N round-trips on each sort interval, and if one provider hangs, the lock is held until it returns — **every block fetch in the pool wedged for the duration**. A single slow provider would take down the whole pool, the exact failure the fallback-provider work in #198 exists to prevent.

## What changed

Snapshot under the lock, fetch unlocked, then publish under the lock only if the pool length still matches the snapshot — otherwise redo the round.

The length is an exact staleness check here: the pool only ever grows through `Add`/`AddNamed` or gets permuted by `Sort` itself, so an unchanged length means no client was added and `sorted` covers the whole pool. Two concurrent `Sort`s keep the length and hold the same *set*, so the loser overwrites the order but never the membership, and the next round settles it. No generation counter needed.

The retry bails on a cancelled context so it cannot spin during shutdown. In practice it fires at most once: pools are built at startup, before `StartSorting`.

`nameAt` drops out of `Sort` and is once again only called under the lock, as its comment requires. No public API change, no new fields or methods.

## Tests

New `rpc/sort_concurrent_test.go` — all three fail against #198's `rpc/sort.go`, pass with the fix:

- `TestSortConcurrentWithPoolAccess` — four concurrent sorters against a goroutine driving `Names`/`WithClients`; the race detector reports 7 `DATA RACE` findings on the unfixed code.
- `TestSortKeepsClientAddedMidRound` — a fetcher that adds a client mid-round; asserts it is not merely kept but sorted into place by the redone round.
- `TestSortStopsRetryingOnCancelledContext` — retry stops on shutdown.

`go test -race -count=2 ./rpc/... ./blockpoller/...` passes; `go build ./...`, `go vet ./rpc/...`, `gofmt -l rpc/` clean.

## Not addressed

Separate review notes on #198, left out to keep this diff to the locking issue:

- With `RollingStrategyAlwaysUseFirst`, the new roll `warn` fires once per `WithClientsContext` call when the primary is down — per block, in `blockpoller`. The roll-per-call behavior is pre-existing; only the log is new.
- `Clients.Reset()` landing while `WithClientsContext` has released the lock around `f` can re-select the provider that just failed and restarts the retry budget.
- `Add`'s auto-name `client-<len>` no longer matches position after a sort, and can collide with an existing name.
- `rolling_strategy.go` has an unreachable second `if s.nextClientIndex == len(clients.clients)` branch.