### PR TITLE
Bump substreams to v1.21.0, release v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,33 @@ Operators, you should copy/paste content of this content straight to your projec
 
 If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you should copy the content between those 2 version to your own repository, replacing placeholder value `fire{chain}` with your chain's own binary.
 
-## Unreleased
+## v1.17.0
 
 ### Added
+
+- New `--substreams-tier2-segment-stall-timeout` flag (default `10m`) on `substreams-tier2`: a segment is now killed when it stops processing blocks for that long, the deadline resetting on every block processed. See the `substreams` bump below for why this replaces the fixed execution budget as the primary guard.
 
 - `rpc.Clients` now tracks a provider name per client. New `AddNamed(client, name)` registers a client under an explicit name, `Add(client)` keeps working unchanged and auto-names the client `client-<index>`, and `Names()` returns all provider names in pool order.
 
 - `rpc.Clients.Reset()` brings the rolling strategy back to the pool's declared order, so the next call goes to the primary provider again. Without it, a `StickyRollingStrategy` that rolled to a fallback after a single transient error stayed on that fallback until the process restarted. `StartSorting` now uses it instead of resetting the strategy itself.
 
 ### Changed
+
+- **Operators** the default of `--substreams-tier2-segment-execution-timeout` moves from `1h` to `4h`. It is now only an absolute backstop, the new `--substreams-tier2-segment-stall-timeout` being the guard that actually kills wedged segments. If you pinned the flag to a value of your own, raise it or drop the override, otherwise expensive-but-healthy segments keep being killed.
+
+- Bumped `substreams` to [v1.21.0](https://github.com/streamingfast/substreams/releases/tag/v1.21.0):
+
+  - Server: tier2 now aborts a segment when it **stops making progress** rather than when it exceeds a fixed time budget. The new stall timeout (10 minutes by default, `--substreams-tier2-segment-stall-timeout`) resets on every block processed, and the pre-existing segment execution timeout (`--substreams-tier2-segment-execution-timeout`) is kept only as an absolute backstop, its default raised from 60 minutes to 4 hours.
+
+    The old fixed budget was fatal to expensive-but-healthy workloads: a segment making thousands of RPC calls per block could take slightly longer than 60 minutes while still advancing block by block, get killed, and — since a killed segment is never cached — have its retry redo the same work and hit the same wall. Such a request could never complete, no matter how many times it reconnected. A stalled segment is still killed promptly, and since a single block is already bounded by the block execution timeout (`--substreams-block-execution-timeout`, 3 minutes by default), the stall timeout cannot be tripped by one legitimately slow block.
+
+    The `request active for a long time` log gained a `since_last_progress` field, and a segment killed for stalling now reports `request stalled, no block progress` instead of `request active for too long`.
+
+  - Server: new `substreams_undo_signal_distance_blocks` prometheus histogram, observing how many blocks each `BlockUndoSignal` sent to clients reverts, labeled by `source` (`reorg` when a fork is seen while streaming, `cursor_resolution` when the cursor of an incoming request points to a block that was reorged out). Its `_count` gives the total number of undo signals sent; subtracting the `le="5"` bucket from it gives the number of large ones. Undo signals reverting more than 5 blocks are also logged as a warning with `trace_id`, `head`, `revert_up_to`, `distance` and, on the `cursor_resolution` path, the client `cursor`.
+
+  - Server: tier2 no longer logs `tls: first record does not look like a TLS handshake` errors from plain-HTTP health probes / load balancers hitting a TLS port (same suppress list as the existing EOF and connection-reset handshake noise).
+
+  - Server: a tier1 shutdown happening while a request was still in its parallel backprocessing phase was reported to the client as `Internal` instead of `Unavailable`, so clients did not see the reconnect signal during a tier1 rollout.
 
 - `rpc.WithClients`/`rpc.WithClientsContext` now attribute each failed attempt to its provider, the returned error reads `provider "<name>": <error>`, and each roll to another provider is logged at `warn` level with the `from_provider`/`to_provider` names. A given `from -> to` roll only warns again once 30s elapsed since the last time it did (the ones in between are logged at `debug` level), so a permanently down provider does not warn on every single call.
 

--- a/cmd/apps/substreams_tier2.go
+++ b/cmd/apps/substreams_tier2.go
@@ -47,7 +47,8 @@ func RegisterSubstreamsTier2App[B firecore.Block](chain *firecore.Chain[B], root
 			cmd.Flags().String("substreams-tier2-authenticator", "trust://", "Authenticator to use for tier2 requests. Can be 'trust://' or 'secret://<key>'. Supports environment variable interpolation with ${ENV_VAR_NAME} syntax, e.g. 'secret://${TIER2_SECRET}'.")
 			cmd.Flags().String("substreams-tier2-discovery-service-url", "", "URL to advertise presence to the grpc discovery service") //traffic-director://xds?vpc_network=vpc-global&use_xds_reds=true
 			cmd.Flags().Uint64("substreams-tier2-max-concurrent-requests", 0, "Maximum number of concurrent requests allowed on the server. When the tier2 service hits this limit, it will set itself as 'Not Ready' until requests are processed. Default 0 (no limit)")
-			cmd.Flags().Duration("substreams-tier2-segment-execution-timeout", time.Hour, "Maximum duration a segment can take to execute before being forcefully stopped with DeadlineExceeded error")
+			cmd.Flags().Duration("substreams-tier2-segment-execution-timeout", 4*time.Hour, "Absolute backstop on a segment execution: maximum duration a segment can take, even while it keeps making progress, before being forcefully stopped with a DeadlineExceeded error")
+			cmd.Flags().Duration("substreams-tier2-segment-stall-timeout", 10*time.Minute, "Maximum duration a segment can go without processing a single block before being forcefully stopped with a DeadlineExceeded error. Keep it well above --substreams-block-execution-timeout, which already bounds a single block")
 			cmd.Flags().String("substreams-tier2-hosted-store-registry-address", "", "gRPC address of the control-plane registry service used to resolve hosted foundational stores (legacy/current stores continue to use the JSON config path)")
 			// all substreams
 			registerCommonSubstreamsFlags(cmd)
@@ -61,6 +62,7 @@ func RegisterSubstreamsTier2App[B firecore.Block](chain *firecore.Chain[B], root
 			maximumConcurrentRequests := viper.GetUint64("substreams-tier2-max-concurrent-requests")
 			executionTimeout := viper.GetDuration("substreams-block-execution-timeout")
 			segmentExecutionTimeout := viper.GetDuration("substreams-tier2-segment-execution-timeout")
+			segmentStallTimeout := viper.GetDuration("substreams-tier2-segment-stall-timeout")
 
 			tracing := os.Getenv("SUBSTREAMS_TRACING") == "modules_exec"
 
@@ -106,6 +108,7 @@ func RegisterSubstreamsTier2App[B firecore.Block](chain *firecore.Chain[B], root
 			config.WASMExtensions = wasmExtensions
 			config.BlockExecutionTimeout = executionTimeout
 			config.SegmentExecutionTimeout = segmentExecutionTimeout
+			config.SegmentStallTimeout = segmentStallTimeout
 			config.MaximumConcurrentRequests = maximumConcurrentRequests
 			config.StoresScratchSpace = firecore.MustReplaceDataDir(runtime.AbsDataDir, viper.GetString("substreams-stores-scratch-space"))
 			config.StoresBackend = viper.GetString("substreams-stores-backend")

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/streamingfast/payment-gateway v0.0.0-20260527144655-d0576d2a4ee3
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0
-	github.com/streamingfast/substreams v1.20.4-0.20260801025548-ba603250f40f
+	github.com/streamingfast/substreams v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/test-go/testify v1.1.4
 	github.com/testcontainers/testcontainers-go v0.43.0

--- a/go.sum
+++ b/go.sum
@@ -2345,8 +2345,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.20.4-0.20260801025548-ba603250f40f h1:U5jj7c/QFxpoPgEwt6FJJ0eps5r2kw/7zgH7bifddAw=
-github.com/streamingfast/substreams v1.20.4-0.20260801025548-ba603250f40f/go.mod h1:L11+nAKugOfDjWV6qleMfDcW5gKrsk/ixTJRNaSjo9M=
+github.com/streamingfast/substreams v1.21.0 h1:NZrFw5IMOFUgM1uBMxicwNYtlJ+yppF7REFJuEg8hbg=
+github.com/streamingfast/substreams v1.21.0/go.mod h1:L11+nAKugOfDjWV6qleMfDcW5gKrsk/ixTJRNaSjo9M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=


### PR DESCRIPTION
Bumps `substreams` to [v1.21.0](https://github.com/streamingfast/substreams/releases/tag/v1.21.0) and cuts the pending `Unreleased` section as **v1.17.0** (minor).

### Operator-visible changes

- New `--substreams-tier2-segment-stall-timeout` flag (default `10m`) on `substreams-tier2`, wired to the new `SegmentStallTimeout` tier2 config. A segment is killed when it stops processing blocks for that long, the deadline resetting on every block processed.
- `--substreams-tier2-segment-execution-timeout` default moves from `1h` to `4h` and becomes an absolute backstop only. Deployments pinning this flag should raise it or drop the override, otherwise expensive-but-healthy segments keep being killed.

Without this wiring the substreams fix would be a no-op for `fire{chain}` operators, since the flag default here overrode the library default.

### Also in the release

The `Unreleased` entries already on `develop` (named RPC providers, provider-attributed errors and sampled roll logs, `rpc.Sort` data race and dropped-client fixes, `tools substreams logs connection --logs=false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)