### PR TITLE
fix(firehose): restart when the hub can no longer link live blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Operators, you should copy/paste content of this content straight to your projec
 
 If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you should copy the content between those 2 version to your own repository, replacing placeholder value `fire{chain}` with your chain's own binary.
 
+## Unreleased
+
+### Fixed
+
+- The `firehose` app now restarts when its block hub can no longer link incoming live blocks, instead of hanging every request at a frozen head indefinitely. A live-source gap whose one-block files were already merged away can never be linked, and `head_block_number`/`finalized_block_number` keep tracking the live source, so the process looked healthy throughout.
+
 ## v1.17.0
 
 ### Added

--- a/firehose/app/firehose/app.go
+++ b/firehose/app/firehose/app.go
@@ -41,6 +41,10 @@ import (
 	"go.uber.org/zap"
 )
 
+// Unlinkable live blocks in a row that mean the hub is wedged for good. Resets on
+// any linkable block and only armed once ready; same value the relayer uses.
+const maxConsecutiveUnlinkableBlocks = 5
+
 type Config struct {
 	MergedBlocksStoreURL    string
 	OneBlocksStoreURL       string
@@ -149,7 +153,15 @@ func (a *App) Run() error {
 		// the hub must hold at least two merged-blocks files worth of final
 		// blocks so the joining source can hand off from a file boundary
 		keepFinalBlocks := int(max(500, 2*bstream.DefaultMergedBlocksBundleSize))
-		forkableHub = hub.NewForkableHubWithOptions(liveSourceFactory, keepFinalBlocks, oneBlocksStore, []hub.Option{hub.WithLogger(a.logger)})
+		forkableHub = hub.NewForkableHubWithOptions(
+			liveSourceFactory,
+			keepFinalBlocks,
+			oneBlocksStore,
+			[]hub.Option{
+				hub.WithLogger(a.logger),
+				hub.WithMaxConsecutiveUnlinkableBlocks(maxConsecutiveUnlinkableBlocks),
+			},
+		)
 		forkableHub.OnTerminated(a.Shutdown)
 
 		go forkableHub.Run()


### PR DESCRIPTION
Pass `hub.WithMaxConsecutiveUnlinkableBlocks(5)` option so the ForkableHub to make it restart after 5 unlinkable blocks. Otherwise it could get stuck forever requiring manual restart.

Similar to this relayer fix: streamingfast/firehose-core@4696483