### PR TITLE
Bump substreams to latest develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 ## Unreleased
 
+### Added
+
+- Bumped `substreams` to [v1.21.1-0.20260810123612-a6afd3480e24](https://github.com/streamingfast/substreams/compare/v1.21.0...a6afd3480e24):
+
+  - Server: `substreams-tier1` emits a periodic `substreams request progress` log per request (after 1 minute, then every 5 minutes) meant to answer "why is my substreams slow?" while the request is still running: phase, per-stage module and job progress, external call cost, last job error, and time spent blocked writing to the consumer. It ends with a short `hints` list naming the likely bottleneck when one is detected. Rates and deltas are suffixed `_5m` and cover a fixed trailing 5 minutes whatever the emission interval is; cadence is tunable with `SUBSTREAMS_PROGRESS_LOG_FIRST_DELAY` and `SUBSTREAMS_PROGRESS_LOG_INTERVAL`.
+
+  - Server: `substreams-tier2` reports its progress every 10 seconds while a block is being processed, instead of only once the block completes, and `ExternalCallMetric` gained `failed_count`, `in_flight_count`, `oldest_in_flight_ms` and `oldest_in_flight_block`. An `eth_call` retrying against an unreachable endpoint is a single wasm extension call that can last minutes: it used to be completely invisible to tier1 until the segment timed out.
+
+  - Server: `substreams-tier1` now restarts when its block hub can no longer link incoming live blocks, the same fix as the `firehose` app one below.
+
 ### Fixed
 
 - The `firehose` app now restarts when its block hub can no longer link incoming live blocks, instead of hanging every request at a frozen head indefinitely. A live-source gap whose one-block files were already merged away can never be linked, and `head_block_number`/`finalized_block_number` keep tracking the live source, so the process looked healthy throughout.

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/streamingfast/payment-gateway v0.0.0-20260527144655-d0576d2a4ee3
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0
-	github.com/streamingfast/substreams v1.21.0
+	github.com/streamingfast/substreams v1.21.1-0.20260810123612-a6afd3480e24
 	github.com/stretchr/testify v1.11.1
 	github.com/test-go/testify v1.1.4
 	github.com/testcontainers/testcontainers-go v0.43.0

--- a/go.sum
+++ b/go.sum
@@ -2345,8 +2345,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.21.0 h1:NZrFw5IMOFUgM1uBMxicwNYtlJ+yppF7REFJuEg8hbg=
-github.com/streamingfast/substreams v1.21.0/go.mod h1:L11+nAKugOfDjWV6qleMfDcW5gKrsk/ixTJRNaSjo9M=
+github.com/streamingfast/substreams v1.21.1-0.20260810123612-a6afd3480e24 h1:G36rHghTrrlVZXGQNuugGUqSMExtsfcUKepQaF8Cj+8=
+github.com/streamingfast/substreams v1.21.1-0.20260810123612-a6afd3480e24/go.mod h1:L11+nAKugOfDjWV6qleMfDcW5gKrsk/ixTJRNaSjo9M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=


### PR DESCRIPTION
Bumps `github.com/streamingfast/substreams` from `v1.21.0` to `v1.21.1-0.20260810123612-a6afd3480e24` ([compare](https://github.com/streamingfast/substreams/compare/v1.21.0...a6afd3480e24)) and copies the relevant changelog entries into the `Unreleased` section.

Picked up:
- tier1 periodic `substreams request progress` log (why is my substreams slow, while it runs)
- tier2 in-block progress reporting every 10s + new `ExternalCallMetric` fields
- tier1 restart when the hub can no longer link live blocks (matches the `firehose` app fix already in `Unreleased`)

The substreams-CLI-only `substreams tools simulate-slow-reader` command is not listed, `fire{chain}` binaries do not ship it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)