### PR TITLE
Bump firehose-networks to v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 ### Added
 
+- Bumped `firehose-networks` to [v0.2.3](https://github.com/streamingfast/firehose-networks/releases/tag/v0.2.3): the Ethereum Hoodi testnet (`hoodi`, `eip155:560048`) now resolves to StreamingFast Firehose and Substreams endpoints (`hoodi.eth.streamingfast.io:443`) instead of only the Pinax ones listed by the upstream networks registry.
+
 - Bumped `substreams` to [v1.21.1-0.20260810123612-a6afd3480e24](https://github.com/streamingfast/substreams/compare/v1.21.0...a6afd3480e24):
 
   - Server: `substreams-tier1` emits a periodic `substreams request progress` log per request (after 1 minute, then every 5 minutes) meant to answer "why is my substreams slow?" while the request is still running: phase, per-stage module and job progress, external call cost, last job error, and time spent blocked writing to the consumer. It ends with a short `hints` list naming the likely bottleneck when one is detected. Rates and deltas are suffixed `_5m` and cover a fixed trailing 5 minutes whatever the emission interval is; cadence is tunable with `SUBSTREAMS_PROGRESS_LOG_FIRST_DELAY` and `SUBSTREAMS_PROGRESS_LOG_INTERVAL`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 ### Added
 
-- Bumped `firehose-networks` to [v0.2.3](https://github.com/streamingfast/firehose-networks/releases/tag/v0.2.3): the Ethereum Hoodi testnet (`hoodi`, `eip155:560048`) now resolves to StreamingFast Firehose and Substreams endpoints (`hoodi.eth.streamingfast.io:443`) instead of only the Pinax ones listed by the upstream networks registry.
+- Bumped `firehose-networks` to [v0.2.3](https://github.com/streamingfast/firehose-networks/releases/tag/v0.2.3): Added Ethereum Hoodi testnet (`hoodi`, `eip155:560048`)  StreamingFast Firehose and Substreams endpoints (`hoodi.eth.streamingfast.io:443`).
 
 - Bumped `substreams` to [v1.21.1-0.20260810123612-a6afd3480e24](https://github.com/streamingfast/substreams/compare/v1.21.0...a6afd3480e24):
 

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/streamingfast/dmetrics v0.0.0-20260109212625-35256f512c62
 	github.com/streamingfast/dsession v0.0.0-20260414190543-79b9846e7c58
 	github.com/streamingfast/dstore v0.2.4-0.20260709193311-122163592902
-	github.com/streamingfast/firehose-networks v0.2.2
+	github.com/streamingfast/firehose-networks v0.2.3
 	github.com/streamingfast/logging v1.2.2
 	github.com/streamingfast/payment-gateway v0.0.0-20260527144655-d0576d2a4ee3
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437

--- a/go.sum
+++ b/go.sum
@@ -2318,8 +2318,8 @@ github.com/streamingfast/eth-go v0.0.0-20260216202159-4e2b7501894a h1:jHKRM0gM5G
 github.com/streamingfast/eth-go v0.0.0-20260216202159-4e2b7501894a/go.mod h1:1szIYZI+rTjWWVYd1kFJomFiPCMvcZfBmylCwRaK8yY=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20251113151010-c9c94d64348a h1:qatil0YhFzTVAFQnH7iMcq+gpVUNEs9Se3lLq4eaof8=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20251113151010-c9c94d64348a/go.mod h1:CG22ObinxSbKIP19bAj0uro0a290kzZTiBbjL8VR0SE=
-github.com/streamingfast/firehose-networks v0.2.2 h1:araNCSHVa9C8+7hGrxNJYt8TlbK65kNDxQMBJuzBjxA=
-github.com/streamingfast/firehose-networks v0.2.2/go.mod h1:/XyroRcAUOO9DdxdgHktuVI1U6uKgjj6+1r+zgLEb90=
+github.com/streamingfast/firehose-networks v0.2.3 h1:kFqhWlp5QtkKW9kezee0cqVjZlChEMGqlkrHK+mtj38=
+github.com/streamingfast/firehose-networks v0.2.3/go.mod h1:/XyroRcAUOO9DdxdgHktuVI1U6uKgjj6+1r+zgLEb90=
 github.com/streamingfast/google-cloud-go v0.0.0-20241202194114-f77ff78d4f66 h1:c0cmKOyazz58F94SwI5a9qZswiJxk0cXSq08mhBGFAI=
 github.com/streamingfast/google-cloud-go v0.0.0-20241202194114-f77ff78d4f66/go.mod h1:SzlutmqoI//WgCLSNcuZ9qO52q+3nYNS2J7vOLlB6kI=
 github.com/streamingfast/logging v0.0.0-20210811175431-f3b44b61606a/go.mod h1:4GdqELhZOXj4xwc4IaBmzofzdErGynnaSzuzxy0ZIBo=


### PR DESCRIPTION
Bumps `github.com/streamingfast/firehose-networks` from `v0.2.2` to [`v0.2.3`](https://github.com/streamingfast/firehose-networks/releases/tag/v0.2.3).

The new version adds a "service overrides" mechanism that merges extra endpoints into networks already present in the upstream Graph networks registry (overridden endpoints take precedence, duplicates dropped), and uses it to register StreamingFast Firehose and Substreams endpoints for the Ethereum Hoodi testnet (`hoodi`, `eip155:560048`), which upstream only lists with Pinax endpoints.

Verified against the bumped dependency:

```
id=hoodi caip2=eip155:560048
firehose-endpoint="hoodi.eth.streamingfast.io:443" substreams-endpoint="hoodi.eth.streamingfast.io:443"
services.firehose=[hoodi.eth.streamingfast.io:443 hoodi.firehose.pinax.network:443]
services.substreams=[hoodi.eth.streamingfast.io:443 hoodi.substreams.pinax.network:443]
```

The change is additive and backward compatible: no code changes were needed, only `go.mod`/`go.sum` and the changelog.

`go build ./...` and `go test ./...` both pass (no failures before or after the bump).