### PR TITLE
Bump substreams to latest develop + fix superviser restart deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 - The `firehose` app now restarts when its block hub can no longer link incoming live blocks, instead of hanging every request at a frozen head indefinitely. A live-source gap whose one-block files were already merged away can never be linked, and `head_block_number`/`finalized_block_number` keep tracking the live source, so the process looked healthy throughout.
 
+- Restarting a supervised node process no longer deadlocks the whole superviser. `Start` waited for a previous process still stopping while holding the lock that also guards `IsRunning`, `LastExitCode` and `Stopped`, so a process that never reached a final state — one ignoring `SIGTERM`, or whose children keep its stdout/stderr open — froze every one of those calls forever. Waiting no longer holds that lock, and `Start` now gives up after 30s with an error instead of blocking indefinitely.
+
 ## v1.17.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,15 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 - Bumped `firehose-networks` to [v0.2.3](https://github.com/streamingfast/firehose-networks/releases/tag/v0.2.3): Added Ethereum Hoodi testnet (`hoodi`, `eip155:560048`)  StreamingFast Firehose and Substreams endpoints (`hoodi.eth.streamingfast.io:443`).
 
-- Bumped `substreams` to [v1.21.1-0.20260810123612-a6afd3480e24](https://github.com/streamingfast/substreams/compare/v1.21.0...a6afd3480e24):
+- Bumped `substreams` to [v1.21.1-0.20260811030713-864626c02e63](https://github.com/streamingfast/substreams/compare/v1.21.0...864626c02e63):
 
   - Server: `substreams-tier1` emits a periodic `substreams request progress` log per request (after 1 minute, then every 5 minutes) meant to answer "why is my substreams slow?" while the request is still running: phase, per-stage module and job progress, external call cost, last job error, and time spent blocked writing to the consumer. It ends with a short `hints` list naming the likely bottleneck when one is detected. Rates and deltas are suffixed `_5m` and cover a fixed trailing 5 minutes whatever the emission interval is; cadence is tunable with `SUBSTREAMS_PROGRESS_LOG_FIRST_DELAY` and `SUBSTREAMS_PROGRESS_LOG_INTERVAL`.
 
   - Server: `substreams-tier2` reports its progress every 10 seconds while a block is being processed, instead of only once the block completes, and `ExternalCallMetric` gained `failed_count`, `in_flight_count`, `oldest_in_flight_ms` and `oldest_in_flight_block`. An `eth_call` retrying against an unreachable endpoint is a single wasm extension call that can last minutes: it used to be completely invisible to tier1 until the segment timed out.
 
   - Server: `substreams-tier1` now restarts when its block hub can no longer link incoming live blocks, the same fix as the `firehose` app one below.
+
+  - Server: the `incoming Substreams Blocks request` log of `substreams-tier1` now carries a `parallelism` object (requested, granted by the authentication layer, effective count and which of the two capped it, plan tier, stage layer executors) plus `parallel_segment_count` and `stage_count`. A client asking for 300 parallel workers and getting 15 previously left no trace of the negotiation in the logs.
 
 ### Fixed
 

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/streamingfast/payment-gateway v0.0.0-20260527144655-d0576d2a4ee3
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0
-	github.com/streamingfast/substreams v1.21.1-0.20260810123612-a6afd3480e24
+	github.com/streamingfast/substreams v1.21.1-0.20260811030713-864626c02e63
 	github.com/stretchr/testify v1.11.1
 	github.com/test-go/testify v1.1.4
 	github.com/testcontainers/testcontainers-go v0.43.0

--- a/go.sum
+++ b/go.sum
@@ -2345,8 +2345,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.21.1-0.20260810123612-a6afd3480e24 h1:G36rHghTrrlVZXGQNuugGUqSMExtsfcUKepQaF8Cj+8=
-github.com/streamingfast/substreams v1.21.1-0.20260810123612-a6afd3480e24/go.mod h1:L11+nAKugOfDjWV6qleMfDcW5gKrsk/ixTJRNaSjo9M=
+github.com/streamingfast/substreams v1.21.1-0.20260811030713-864626c02e63 h1:VkEQ6m8gp11cq3ts97XEfgBnNW6nMwkw2KKtmztjTtg=
+github.com/streamingfast/substreams v1.21.1-0.20260811030713-864626c02e63/go.mod h1:p7CaQ22aRhaONTN6yCUoD4tq4T4W5rJZD24HqLWVsIc=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=

--- a/node-manager/superviser/superviser.go
+++ b/node-manager/superviser/superviser.go
@@ -37,6 +37,12 @@ type mindreaderPlugin interface {
 	LastSeenBlock() bstream.BlockRef
 }
 
+// stoppingWaitTimeout is how long `Start` waits for a previous command still in the
+// `STOPPING` state before giving up. A supervised process that ignores SIGTERM, or whose
+// children keep its stdout/stderr open, never reaches a final state and would otherwise
+// block the restart forever. It is a variable only so that tests can shorten it.
+var stoppingWaitTimeout = 30 * time.Second
+
 type Superviser struct {
 	*shutter.Shutter
 	Binary    string
@@ -48,6 +54,14 @@ type Superviser struct {
 	Env    []string
 	Logger *zap.Logger
 
+	// runLock serializes the process lifecycle operations (`Start` and `Stop`) against
+	// each other. It is held for the whole duration of those operations, including while
+	// waiting for the underlying process to actually terminate.
+	runLock sync.Mutex
+
+	// cmdLock guards access to `cmd` only. It must never be held while waiting on
+	// anything, otherwise observers like `IsRunning`, `LastExitCode` and `Stopped` block
+	// for as long as the wait lasts (and deadlock outright when the wait never completes).
 	cmd     *overseer.Cmd
 	cmdLock sync.Mutex
 
@@ -113,22 +127,32 @@ func (s *Superviser) setDeepMindDebug(enabled bool) {
 	}
 }
 
-func (s *Superviser) Stopped() <-chan struct{} {
+// getCmd returns the current command, or `nil` if there is none. The lock is released
+// before returning, the caller is free to block on the returned command.
+func (s *Superviser) getCmd() *overseer.Cmd {
 	s.cmdLock.Lock()
 	defer s.cmdLock.Unlock()
 
-	if s.cmd != nil {
-		return s.cmd.Done()
+	return s.cmd
+}
+
+func (s *Superviser) setCmd(cmd *overseer.Cmd) {
+	s.cmdLock.Lock()
+	defer s.cmdLock.Unlock()
+
+	s.cmd = cmd
+}
+
+func (s *Superviser) Stopped() <-chan struct{} {
+	if cmd := s.getCmd(); cmd != nil {
+		return cmd.Done()
 	}
 	return nil
 }
 
 func (s *Superviser) LastExitCode() int {
-	s.cmdLock.Lock()
-	defer s.cmdLock.Unlock()
-
-	if s.cmd != nil {
-		return s.cmd.Status().Exit
+	if cmd := s.getCmd(); cmd != nil {
+		return cmd.Status().Exit
 	}
 	return 0
 }
@@ -172,18 +196,25 @@ func (s *Superviser) Start(options ...nodeManager.StartOption) error {
 		plugin.Launch()
 	}
 
-	s.cmdLock.Lock()
-	defer s.cmdLock.Unlock()
+	s.runLock.Lock()
+	defer s.runLock.Unlock()
 
-	if s.cmd != nil {
-		if s.cmd.State == overseer.STARTING || s.cmd.State == overseer.RUNNING {
+	if cmd := s.getCmd(); cmd != nil {
+		if cmd.IsRunningState() {
 			s.Logger.Info("underlying process already running, nothing to do")
 			return nil
 		}
 
-		if s.cmd.State == overseer.STOPPING {
+		if cmdIsStopping(cmd) {
 			s.Logger.Info("underlying process is currently stopping, waiting for it to finish")
-			<-s.cmd.Done()
+
+			// A previous process that never reaches its final state would otherwise wedge
+			// the superviser forever, so we give up after a while and report it instead.
+			select {
+			case <-cmd.Done():
+			case <-time.After(stoppingWaitTimeout):
+				return fmt.Errorf("previous process is still stopping after %s, refusing to start a new one", stoppingWaitTimeout)
+			}
 		}
 	}
 
@@ -216,9 +247,10 @@ func (s *Superviser) Start(options ...nodeManager.StartOption) error {
 		zap.Strings("arguments", s.Arguments),
 		zap.Any("env", explodeToMap(envToLog)))
 
-	s.cmd = overseer.NewCmd(s.Binary, s.Arguments, overseer.Options{Streaming: true, Env: env})
+	cmd := overseer.NewCmd(s.Binary, s.Arguments, overseer.Options{Streaming: true, Env: env})
+	s.setCmd(cmd)
 
-	go s.start(s.cmd)
+	go s.start(cmd)
 
 	return nil
 }
@@ -233,20 +265,24 @@ func explodeToMap(env []string) map[string]string {
 }
 
 func (s *Superviser) Stop() error {
-	s.cmdLock.Lock()
-	defer s.cmdLock.Unlock()
+	s.runLock.Lock()
+	defer s.runLock.Unlock()
 
 	s.Logger.Info("supervisor received a stop request, terminating supervised node process")
 
-	if !s.isRunning() {
+	cmd := s.getCmd()
+	if !cmdIsRunning(cmd) {
 		s.Logger.Info("underlying process is not running, nothing to do")
 		return nil
 	}
 
-	if s.cmd.State == overseer.STARTING || s.cmd.State == overseer.RUNNING {
+	if cmd.IsRunningState() {
 		s.Logger.Info("stopping underlying process")
-		err := s.cmd.Stop()
-		if err != nil {
+		if err := cmd.Stop(); err != nil {
+			// The command is left in place on purpose even though `Stop` already flipped it
+			// to `STOPPING`: the process may well still be alive, and dropping our handle on
+			// it would let a later `Start` spawn a second process over the same data. A
+			// later `Start` bails out through `stoppingWaitTimeout` instead.
 			s.Logger.Error("failed to stop overseer cmd", zap.Error(err))
 			return err
 		}
@@ -258,7 +294,7 @@ func (s *Superviser) Stop() error {
 nodeProcessDone:
 	for {
 		select {
-		case <-s.cmd.Done():
+		case <-cmd.Done():
 			break nodeProcessDone
 		case <-time.After(500 * time.Millisecond):
 			s.Logger.Debug("still blocking until command actually ends")
@@ -267,61 +303,59 @@ nodeProcessDone:
 
 	s.Logger.Info("supervised process has been terminated")
 
-	s.Logger.Info("waiting for stdout and stderr to be drained", s.getProcessOutputStatsLogFields()...)
-	for {
-		if s.isBufferEmpty() {
-			break
-		}
-
-		s.Logger.Debug("draining stdout and stderr", s.getProcessOutputStatsLogFields()...)
+	s.Logger.Info("waiting for stdout and stderr to be drained", cmdOutputStatsLogFields(cmd)...)
+	for !cmdBufferEmpty(cmd) {
+		s.Logger.Debug("draining stdout and stderr", cmdOutputStatsLogFields(cmd)...)
 		time.Sleep(500 * time.Millisecond)
 	}
 
 	s.Logger.Info("stdout and stderr are now drained")
 
-	// Must be after `for { ... }` as `s.cmd` is used within the loop and also before it via call to `getProcessOutputStatsLogFields`
-	s.cmd = nil
+	s.setCmd(nil)
 
 	return nil
 }
 
-func (s *Superviser) getProcessOutputStats() (stdoutLineCount, stderrLineCount int) {
-	// Capture s.cmd in local variable to prevent race condition with termination
-	if cmd := s.cmd; cmd != nil {
-		return len(cmd.Stdout), len(cmd.Stderr)
+func cmdOutputStatsLogFields(cmd *overseer.Cmd) []zap.Field {
+	var stdoutLineCount, stderrLineCount int
+	if cmd != nil {
+		stdoutLineCount, stderrLineCount = len(cmd.Stdout), len(cmd.Stderr)
 	}
-
-	return
-}
-
-func (s *Superviser) getProcessOutputStatsLogFields() []zap.Field {
-	stdoutLineCount, stderrLineCount := s.getProcessOutputStats()
 
 	return []zap.Field{zap.Int("stdout_len", stdoutLineCount), zap.Int("stderr_len", stderrLineCount)}
 }
 
 func (s *Superviser) IsRunning() bool {
-	s.cmdLock.Lock()
-	defer s.cmdLock.Unlock()
-
-	return s.isRunning()
+	return cmdIsRunning(s.getCmd())
 }
 
-// This one assuming the lock is properly held already
-func (s *Superviser) isRunning() bool {
-	if s.cmd == nil {
+// cmdIsRunning reports whether the command is starting, running or stopping.
+//
+// overseer guards `Cmd.State` with an unexported lock, reading the field directly races
+// with the command's own goroutine, so everything here goes through the locked accessors
+// it exposes. Not being initial nor final leaves exactly those three states.
+func cmdIsRunning(cmd *overseer.Cmd) bool {
+	if cmd == nil {
 		return false
 	}
-	return s.cmd.State == overseer.STARTING || s.cmd.State == overseer.RUNNING || s.cmd.State == overseer.STOPPING
+	return !cmd.IsInitialState() && !cmd.IsFinalState()
 }
 
-func (s *Superviser) isBufferEmpty() bool {
-	// Capture s.cmd in local variable to prevent race condition with termination
-	if cmd := s.cmd; cmd != nil {
-		return len(cmd.Stdout) == 0 && len(cmd.Stderr) == 0
+// cmdIsStopping reports whether the command is in the `STOPPING` state, which overseer
+// has no accessor for, so we exclude every other non-final state instead.
+func cmdIsStopping(cmd *overseer.Cmd) bool {
+	if cmd == nil {
+		return false
 	}
-	
-	return true
+	return !cmd.IsInitialState() && !cmd.IsRunningState() && !cmd.IsFinalState()
+}
+
+func cmdBufferEmpty(cmd *overseer.Cmd) bool {
+	if cmd == nil {
+		return true
+	}
+
+	return len(cmd.Stdout) == 0 && len(cmd.Stderr) == 0
 }
 
 func (s *Superviser) start(cmd *overseer.Cmd) {
@@ -333,7 +367,7 @@ func (s *Superviser) start(cmd *overseer.Cmd) {
 		case status := <-statusChan:
 			processTerminated = true
 			if status.Exit == 0 {
-				s.Logger.Info("command terminated with zero status", s.getProcessOutputStatsLogFields()...)
+				s.Logger.Info("command terminated with zero status", cmdOutputStatsLogFields(cmd)...)
 			} else {
 				s.Logger.Error(fmt.Sprintf("command terminated with non-zero status, last log lines:\n%s\n", formatLogLines(s.LastLogLines())), overseerStatusLogFields(status)...)
 			}
@@ -345,8 +379,8 @@ func (s *Superviser) start(cmd *overseer.Cmd) {
 		}
 
 		if processTerminated {
-			s.Logger.Debug("command terminated but continue read loop to fully consume stdout/sdterr line channels", zap.Bool("buffer_empty", s.isBufferEmpty()))
-			if s.isBufferEmpty() {
+			s.Logger.Debug("command terminated but continue read loop to fully consume stdout/sdterr line channels", zap.Bool("buffer_empty", cmdBufferEmpty(cmd)))
+			if cmdBufferEmpty(cmd) {
 				return
 			}
 		}

--- a/node-manager/superviser/superviser_race_test.go
+++ b/node-manager/superviser/superviser_race_test.go
@@ -2,12 +2,15 @@ package superviser
 
 import (
 	"sync"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/ShinyTrinkets/overseer"
 	"github.com/streamingfast/bstream"
 	logplugin "github.com/streamingfast/firehose-core/node-manager/log_plugin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // fakeMindreaderPlugin mimics mindreader.MindReaderPlugin before any block has
@@ -29,6 +32,89 @@ func TestSuperviser_LastSeenBlockNumWithoutAnyBlockSeen(t *testing.T) {
 	assert.Equal(t, uint64(0), superviser.LastSeenBlockNum())
 }
 
+// TestSuperviser_ObserversStayResponsiveWhileStartWaitsForPreviousProcess covers the
+// deadlock that hung CI for the full 10 minutes test timeout: Start() used to block on
+// `<-s.cmd.Done()` of a still `STOPPING` command while holding cmdLock, so every observer
+// (IsRunning, LastExitCode, Stopped) waited on that same lock. When the previous process
+// never reached a final state, the lock was never released and the whole superviser wedged.
+//
+// `testing/synctest` cannot drive this test: the superviser supervises a real OS process,
+// and the goroutines draining its stdout/stderr sit in a `read` syscall, which does not
+// count as durably blocked. A bubble only advances its fake clock once every goroutine in
+// it is durably blocked, so the `stoppingWaitTimeout` timer below would never fire and the
+// bubble would hang until the test timeout instead.
+func TestSuperviser_ObserversStayResponsiveWhileStartWaitsForPreviousProcess(t *testing.T) {
+	// Long enough that the observers below are probed while Start() is still waiting on the
+	// stopping command, short enough to keep the test quick.
+	previousTimeout := stoppingWaitTimeout
+	stoppingWaitTimeout = 2 * time.Second
+	defer func() { stoppingWaitTimeout = previousTimeout }()
+
+	// The script ignores SIGTERM, so the command stays in `STOPPING` forever once stopped,
+	// exactly like a supervised process whose children keep its stdout/stderr open.
+	superviser := testSuperviserSh(`trap '' TERM` + infiniteScript)
+	lineChan := registerLineChanPlugin(superviser)
+
+	go superviser.Start()
+	waitForSuperviserTaskCompletion(t, superviser)
+	waitForOutput(t, lineChan, waitDefaultTimeout)
+
+	cmd := superviser.getCmd()
+	require.NotNil(t, cmd)
+	require.NoError(t, cmd.Stop())
+	require.Eventually(t, func() bool {
+		return cmdIsStopping(cmd)
+	}, 5*time.Second, 5*time.Millisecond, "command never reached the STOPPING state")
+
+	// SIGTERM is ignored, only SIGKILL takes that process group down. We deliberately do
+	// not call Stop() here: should this test ever fail again, Stop() would be waiting on
+	// the very lock the failure is about and turn a clean failure into a hung test binary.
+	t.Cleanup(func() {
+		assert.NoError(t, cmd.Signal(syscall.SIGKILL))
+	})
+
+	startReturned := make(chan struct{})
+	go func() {
+		defer close(startReturned)
+		_ = superviser.Start()
+	}()
+
+	// Let Start() reach the point where it waits on the stopping command.
+	select {
+	case <-startReturned:
+		require.Fail(t, "Start() returned before it even waited on the stopping command")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	// The observers must answer right away, they must not wait on the stopping command.
+	for _, observer := range []struct {
+		name string
+		call func()
+	}{
+		{"IsRunning", func() { superviser.IsRunning() }},
+		{"LastExitCode", func() { superviser.LastExitCode() }},
+		{"Stopped", func() { superviser.Stopped() }},
+	} {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			observer.call()
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "observer blocked", "%s() blocked while Start() waits for the stopping command", observer.name)
+		}
+	}
+
+	select {
+	case <-startReturned:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "Start() never returned while the previous command stayed in STOPPING")
+	}
+}
+
 // TestSuperviser_StoppedAndLastExitCodeConcurrentWithStop ensures Stopped()
 // and LastExitCode() take cmdLock: Stop() sets s.cmd = nil under that lock
 // while other goroutines may be reading it. We reproduce the exact write
@@ -39,18 +125,16 @@ func TestSuperviser_StoppedAndLastExitCodeConcurrentWithStop(t *testing.T) {
 	superviser := testSuperviserInfinite()
 
 	var wg sync.WaitGroup
-	for g := 0; g < 4; g++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for i := 0; i < 1000; i++ {
+	for range 4 {
+		wg.Go(func() {
+			for range 1000 {
 				_ = superviser.Stopped()
 				_ = superviser.LastExitCode()
 			}
-		}()
+		})
 	}
 
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		// Same write Start() does when (re)creating the command
 		superviser.cmdLock.Lock()
 		superviser.cmd = overseer.NewCmd(superviser.Binary, superviser.Arguments)

--- a/node-manager/superviser/superviser_test.go
+++ b/node-manager/superviser/superviser_test.go
@@ -22,6 +22,7 @@ import (
 	logplugin "github.com/streamingfast/firehose-core/node-manager/log_plugin"
 	"github.com/streamingfast/logging"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -52,14 +53,11 @@ func TestSuperviser_StartsCorrectly(t *testing.T) {
 	superviser := testSuperviserInfinite()
 	defer superviser.Stop()
 
-	lineChan := make(chan string)
-	superviser.RegisterLogPlugin(logplugin.LogPluginFunc(func(line string) {
-		lineChan <- line
-	}))
+	lineChan := registerLineChanPlugin(superviser)
 
 	go superviser.Start()
 
-	waitForSuperviserTaskCompletion(superviser)
+	waitForSuperviserTaskCompletion(t, superviser)
 	waitForOutput(t, lineChan, waitDefaultTimeout)
 
 	assert.Equal(t, true, superviser.IsRunning())
@@ -69,20 +67,17 @@ func TestSuperviser_CanBeRestartedCorrectly(t *testing.T) {
 	superviser := testSuperviserInfinite()
 	defer superviser.Stop()
 
-	lineChan := make(chan string)
-	superviser.RegisterLogPlugin(logplugin.LogPluginFunc(func(line string) {
-		lineChan <- line
-	}))
+	lineChan := registerLineChanPlugin(superviser)
 
 	go superviser.Start()
-	waitForSuperviserTaskCompletion(superviser)
+	waitForSuperviserTaskCompletion(t, superviser)
 	waitForOutput(t, lineChan, waitDefaultTimeout)
 
-	superviser.Stop()
+	require.NoError(t, superviser.Stop())
 	assert.Equal(t, false, superviser.IsRunning())
 
 	go superviser.Start()
-	waitForSuperviserTaskCompletion(superviser)
+	waitForSuperviserTaskCompletion(t, superviser)
 	waitForOutput(t, lineChan, waitDefaultTimeout)
 
 	assert.Equal(t, true, superviser.IsRunning())
@@ -92,13 +87,10 @@ func TestSuperviser_CapturesStdoutCorrectly(t *testing.T) {
 	superviser := testSuperviserSh("echo first; sleep 0.1; echo second")
 	defer superviser.Stop()
 
-	lineChan := make(chan string)
-	superviser.RegisterLogPlugin(logplugin.LogPluginFunc(func(line string) {
-		lineChan <- line
-	}))
+	lineChan := registerLineChanPlugin(superviser)
 
 	go superviser.Start()
-	waitForSuperviserTaskCompletion(superviser)
+	waitForSuperviserTaskCompletion(t, superviser)
 
 	var lines []string
 	lines = append(lines, waitForOutput(t, lineChan, waitDefaultTimeout))
@@ -119,9 +111,29 @@ func testSuperviserInfinite() *Superviser {
 	return testSuperviserSh(infiniteScript)
 }
 
-func waitForSuperviserTaskCompletion(superviser *Superviser) {
-	superviser.cmdLock.Lock()
-	superviser.cmdLock.Unlock()
+// registerLineChanPlugin registers a log plugin forwarding every line to the returned
+// channel. The channel is buffered and never blocks the superviser read loop: a blocked
+// read loop stops draining overseer's stdout/stderr channels, which in turn keeps the
+// underlying `exec.Cmd.Wait` from ever returning, so the command never reaches a final
+// state and `Done()` never fires.
+func registerLineChanPlugin(superviser *Superviser) chan string {
+	lineChan := make(chan string, 1024)
+	superviser.RegisterLogPlugin(logplugin.LogPluginFunc(func(line string) {
+		select {
+		case lineChan <- line:
+		default:
+		}
+	}))
+
+	return lineChan
+}
+
+func waitForSuperviserTaskCompletion(t *testing.T, superviser *Superviser) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		return superviser.getCmd() != nil
+	}, 5*time.Second, 2*time.Millisecond, "superviser never created its command")
 }
 
 func waitForOutput(t *testing.T, lineChan chan string, timeout time.Duration) (line string) {


### PR DESCRIPTION
## Substreams bump

Bumps `github.com/streamingfast/substreams` to `v1.21.1-0.20260811030713-864626c02e63` (latest `develop`).

- [substreams#866](https://github.com/streamingfast/substreams/pull/866) — `substreams-tier1` now logs the parallel-worker negotiation. The `incoming Substreams Blocks request` entry carries a `parallelism` object (requested, granted by the authentication layer, effective count and which of the two capped it, plan tier, stage layer executors) plus `parallel_segment_count` and `stage_count`.
- `firehose-networks` bump to v0.2.3 on the substreams side, matching the one already vendored here.

## Superviser deadlock fix

CI on this branch hung for the full 10 minutes test timeout in `TestSuperviser_CanBeRestartedCorrectly`. The failure is **not** caused by the bump — the same hang happened on 2026-08-04 on an unrelated dependabot branch — but it blocks this PR from going green, so it is fixed here rather than parked.

`Start()` waited for a previous command still in `STOPPING` while holding `cmdLock`, the same lock `IsRunning()`, `LastExitCode()` and `Stopped()` take. A process that never reaches a final state — one ignoring `SIGTERM`, or whose children keep its stdout/stderr open so `exec.Cmd.Wait` never returns — left that lock held forever and wedged the whole superviser.

- `runLock` now serializes the `Start`/`Stop` lifecycle and may be held across waits; `cmdLock` only guards the `cmd` field and is never held while waiting.
- `Start()` gives up after `stoppingWaitTimeout` (30s) with an error instead of blocking indefinitely.
- A failed `cmd.Stop()` deliberately keeps the command in place — dropping it would let a later `Start()` spawn a second process over the same data.
- overseer state is read through its locked accessors; `Cmd.State` is guarded by an unexported lock and reading it directly raced with the command's own goroutine.
- The tests fed log lines into an unbuffered channel, so the read loop blocked, stopped draining overseer's stdout/stderr and kept the command from ever completing. That is what made the deadlock reachable from CI.

## Verification

- New regression test asserts the observers stay responsive while `Start()` waits; confirmed it fails against the old locking and passes against the new.
- `go test ./...` and `go test -race ./node-manager/superviser/` pass, plus a stress run of 4 concurrent instances × 25 iterations on a CPU-throttled Linux container shaped like CI.