### PR TITLE
Speed up prune-states and prune-outputs deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 ## Unreleased
 
+### Changed
+
+- `firecore tools substreams prune-states` and `prune-outputs` delete much faster: deletions now run on their own `--delete-parallelism` (250 by default) instead of sharing the listing's `--parallelism` (16 and 64), each attempt is bounded at 5s instead of 30s, and a failed deletion is retried once after 50ms instead of four times over 7.5s. A deletion that still fails is reported as before and picked up by the next run.
+
 ### Added
 
 - `firecore tools substreams purge`, `prune-states` and `prune-outputs` all skip any module folder carrying a `DO_NOT_PRUNE` file at its root, next to the `last_used*.zst` markers, and report how many folders that spared.

--- a/cmd/tools/substreams/prune_outputs.go
+++ b/cmd/tools/substreams/prune_outputs.go
@@ -97,6 +97,7 @@ func NewToolsPruneOutputsCmd(logger *zap.Logger) *cobra.Command {
 				dryRun:                 sflags.MustGetBool(cmd, "dry-run"),
 				force:                  sflags.MustGetBool(cmd, "force"),
 				parallelism:            sflags.MustGetInt(cmd, "parallelism"),
+				deleteParallelism:      sflags.MustGetInt(cmd, "delete-parallelism"),
 				now:                    time.Now(),
 			}
 			cmd.SilenceUsage = true
@@ -109,7 +110,8 @@ func NewToolsPruneOutputsCmd(logger *zap.Logger) *cobra.Command {
 	cmd.Flags().String("output-module-minimum-age", "", "If set, also prune modules carrying an spkg (directly-queried output modules), using this age instead of --minimum-age. Unset or '0' keeps them untouched")
 	cmd.Flags().BoolP("dry-run", "n", false, "Only report what would be deleted")
 	cmd.Flags().BoolP("force", "f", false, "Skip the confirmation prompt")
-	cmd.Flags().Int("parallelism", 64, "Number of concurrent listing and deletion operations")
+	cmd.Flags().Int("parallelism", 64, "Number of concurrent listing operations")
+	cmd.Flags().Int("delete-parallelism", 250, "Number of concurrent deletions")
 	cmd.MarkFlagRequired("truncate-below-block")
 	cmd.MarkFlagRequired("minimum-age")
 
@@ -124,8 +126,11 @@ type pruneOutputsConfig struct {
 	outputModuleMinimumAge time.Duration
 	dryRun                 bool
 	force                  bool
-	parallelism            int
-	now                    time.Time
+	// parallelism bounds the listing, deleteParallelism the deletions. Deletions are
+	// round-trip bound and cost nothing locally, so they run far wider than the listing.
+	parallelism       int
+	deleteParallelism int
+	now               time.Time
 }
 
 type outputFile struct {
@@ -145,6 +150,9 @@ type prunedModule struct {
 func runPruneOutputs(ctx context.Context, storeURL string, cfg pruneOutputsConfig, logger *zap.Logger) error {
 	if cfg.parallelism < 1 {
 		cfg.parallelism = 1
+	}
+	if cfg.deleteParallelism < 1 {
+		cfg.deleteParallelism = 1
 	}
 
 	store, err := newPurgeStore(ctx, storeURL, cfg.parallelism, logger)
@@ -228,7 +236,7 @@ func runPruneOutputs(ctx context.Context, storeURL string, cfg pruneOutputsConfi
 	}
 
 	fmt.Print(stylex.Labelf("Deleting %d output file(s) (%s)... ", len(toDelete), formatBytes(totalBytes)))
-	if err := deleteAll(ctx, store.store, toDelete, cfg.parallelism); err != nil {
+	if err := deleteAll(ctx, store.store, toDelete, cfg.deleteParallelism); err != nil {
 		fmt.Println(stylex.Error("✗"))
 		return err
 	}

--- a/cmd/tools/substreams/prune_states.go
+++ b/cmd/tools/substreams/prune_states.go
@@ -74,6 +74,7 @@ folder or directly at its 'states' folder, in which case the whole tree is walke
 				dryRun:             sflags.MustGetBool(cmd, "dry-run"),
 				force:              sflags.MustGetBool(cmd, "force"),
 				parallelism:        sflags.MustGetInt(cmd, "parallelism"),
+				deleteParallelism:  sflags.MustGetInt(cmd, "delete-parallelism"),
 				now:                time.Now(),
 			}
 			cmd.SilenceUsage = true
@@ -86,7 +87,8 @@ folder or directly at its 'states' folder, in which case the whole tree is walke
 	cmd.Flags().String("minimum-age", "", "Only delete snapshots last modified longer than this ago, ex: '3d', '72h'. Unset deletes whatever the age")
 	cmd.Flags().BoolP("dry-run", "n", false, "Only report what would be deleted")
 	cmd.Flags().BoolP("force", "f", false, "Skip the confirmation prompt")
-	cmd.Flags().Int("parallelism", 16, "Number of concurrent deletions")
+	cmd.Flags().Int("parallelism", 16, "Number of concurrent listing operations")
+	cmd.Flags().Int("delete-parallelism", 250, "Number of concurrent deletions")
 	cmd.MarkFlagRequired("keep-every")
 	cmd.MarkFlagRequired("truncate-below-block")
 
@@ -98,11 +100,14 @@ type pruneConfig struct {
 	truncateBelowBlock uint64
 	// minimumAge additionally spares snapshots modified more recently than this; zero
 	// disables the age check.
-	minimumAge  time.Duration
-	dryRun      bool
-	force       bool
-	parallelism int
-	now         time.Time
+	minimumAge time.Duration
+	dryRun     bool
+	force      bool
+	// parallelism bounds the listing, deleteParallelism the deletions. Deletions are
+	// round-trip bound and cost nothing locally, so they run far wider than the listing.
+	parallelism       int
+	deleteParallelism int
+	now               time.Time
 }
 
 type snapshotFile struct {
@@ -126,6 +131,9 @@ func runPruneStates(ctx context.Context, storeURL string, cfg pruneConfig, logge
 	}
 	if cfg.parallelism < 1 {
 		cfg.parallelism = 1
+	}
+	if cfg.deleteParallelism < 1 {
+		cfg.deleteParallelism = 1
 	}
 
 	store, err := newPurgeStore(ctx, storeURL, cfg.parallelism, logger)
@@ -194,7 +202,7 @@ func runPruneStates(ctx context.Context, storeURL string, cfg pruneConfig, logge
 	}
 
 	fmt.Print(stylex.Labelf("Deleting %d snapshot(s)... ", len(toDelete)))
-	if err := deleteAll(ctx, store.store, toDelete, cfg.parallelism); err != nil {
+	if err := deleteAll(ctx, store.store, toDelete, cfg.deleteParallelism); err != nil {
 		fmt.Println(stylex.Error("✗"))
 		return err
 	}
@@ -379,12 +387,14 @@ func snapshotsToPrune(files []snapshotFile, keepEvery, truncateBelowBlock uint64
 }
 
 // deleteRetries is how many times a failed deletion is attempted before giving up: object
-// stores throw transient 503s under sustained delete load.
-const deleteRetries = 5
+// stores throw transient 503s under sustained delete load. An attempt holds its worker slot
+// for its whole duration, so a long retry chain costs throughput on every other file; what
+// this leaves behind is reported and picked up by the next run.
+const deleteRetries = 2
 
 // deleteBackoffBase is the delay before the first retry, doubled on each further one. A
 // variable so tests can shrink it.
-var deleteBackoffBase = 500 * time.Millisecond
+var deleteBackoffBase = 50 * time.Millisecond
 
 // deleteWithRetry retries a deletion with exponential backoff, treating a missing object
 // as success. It returns the last error once the attempts are exhausted.

--- a/cmd/tools/substreams/prune_states_test.go
+++ b/cmd/tools/substreams/prune_states_test.go
@@ -209,9 +209,9 @@ func TestDeleteWithRetry(t *testing.T) {
 	defer func() { deleteBackoffBase = savedBackoff }()
 
 	attempts := 0
-	store := flakyDeleteStore{failures: 2, attempts: &attempts}
+	store := flakyDeleteStore{failures: deleteRetries - 1, attempts: &attempts}
 	require.NoError(t, deleteWithRetry(context.Background(), store, "x"))
-	assert.Equal(t, 3, attempts)
+	assert.Equal(t, deleteRetries, attempts)
 
 	attempts = 0
 	store = flakyDeleteStore{failures: deleteRetries + 1, attempts: &attempts}

--- a/cmd/tools/substreams/purge_store.go
+++ b/cmd/tools/substreams/purge_store.go
@@ -483,13 +483,14 @@ func (s *purgeStore) DeleteObject(ctx context.Context, name string) error {
 }
 
 // timeboxedDeleter bounds each deletion attempt on its own, so a hung request burns one
-// retry instead of the whole call.
+// retry instead of the whole call. A deletion the store answers at all answers in well
+// under a second, so a stalled one is better abandoned and retried than waited on.
 type timeboxedDeleter struct {
 	dstore.Store
 }
 
 func (t timeboxedDeleter) DeleteObject(ctx context.Context, name string) error {
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	return t.Store.DeleteObject(ctx, name)
 }


### PR DESCRIPTION
Listing the snapshots and output files to delete was already fast; the deletion phase was not. `deleteAll` is round-trip bound, and its constants were tuned for a phase that also does local work.

Aligned them with `streamingfast/tooling`'s `gcs_fast_delete`, which sustains this rate against GCS:

- **Deletions get their own `--delete-parallelism`, 250 by default**, on both `prune-states` and `prune-outputs`. `--parallelism` (16 and 64) now bounds the listing only, which is where memory and local work actually live.
- **Per-attempt timeout 30s → 5s.** A deletion the store answers at all answers in well under a second, so a stalled one is better abandoned and retried than waited on.
- **`deleteRetries` 5 → 2, `deleteBackoffBase` 500ms → 50ms.** An attempt holds its worker slot for its whole duration, so a long retry chain costs throughput on every other file.

Worst case per object drops from ~157s of a worker slot to ~10s.

`deleteWithRetry` is shared with `purge`, so the retry change applies there too. A deletion that still fails is counted and reported exactly as before, and the next run — or the next `--daemon` interval — picks it up.

Note that 250 workers exceeds the GCS transport's 100 idle connections per host, so past that it pays a TLS handshake per delete. `gcs_fast_delete` runs the same way and is fast in practice; `--delete-parallelism` is there to tune it per backend.

## Test plan

- `go test ./cmd/tools/substreams/` passes; `TestDeleteWithRetry` now derives its attempt counts from `deleteRetries` instead of hardcoding 5.
- Verified both commands expose `--delete-parallelism` with a 250 default, and that `--parallelism` keeps its 16/64 defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)