### PR TITLE
Record block count, size and first block time on merged blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 ### Added
 
+- Added `firecore tools annotate-merged-blocks <gs-store-url>` which records the uncompressed size of every merged-blocks file as a `datasize` custom metadata entry on the object, so the size can be read from a listing instead of by downloading the file.
+
+  Google Cloud Storage only, since it writes object metadata without rewriting the file. Each file is streamed through a zstd decoder into a byte counter and dropped as it decodes, so memory stays flat whatever the file size, and `--parallelism` (32 by default) sets how many files are read at once. Files that a previous run already annotated are skipped straight from the listing, which carries their metadata, so a rerun over a mostly-done store costs one listing and nothing else; `--overwrite` recomputes them. A plain `.dbin` file is never read at all, its object size is already the answer. `--start-block` and `--stop-block` bound the listing service-side, `--dry-run` reports what would be annotated without reading anything.
+
+  Reads and metadata writes are both pinned to the generation and metageneration the listing returned, so a file the merger rewrites mid-run is reported as failed rather than annotated with the size of a version that is gone. `--grpc` switches to the Cloud Storage gRPC API, which on GKE takes the DirectPath route straight to the storage backend, spread over `--grpc-connection-pool` connections (one per 32 of `--parallelism` by default).
+
+  The store URL takes the same two query parameters `dstore` reads off a `gs://` URL: `?project=` bills the reads to that project on a requester-pays bucket, and `?client_protocol=grpc` selects the same transport as `--grpc`. Setting a project turns DirectPath off, since DirectPath does not carry the `x-goog-user-project` header requester-pays billing needs.
+
 - `firecore tools substreams purge`, `prune-states` and `prune-outputs` all skip any module folder carrying a `DO_NOT_PRUNE` file at its root, next to the `last_used*.zst` markers, and report how many folders that spared.
 
 - Added `firecore tools last-oneblock <oneblocks-store>` which prints the highest block number found among the store's one-block files, as a bare number on stdout, exiting non-zero when the store cannot be listed, holds no one-block file, or a filename does not parse as one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,23 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 ### Added
 
-- Added `firecore tools annotate-merged-blocks <gs-store-url>` which records the uncompressed size of every merged-blocks file as a `datasize` custom metadata entry on the object, so the size can be read from a listing instead of by downloading the file.
+- The merger now records what a merged-blocks file holds on the object itself, as three custom metadata entries written as it uploads each bundle: `datasize`, the file's size once decompressed, `itemcount`, the number of blocks it holds, and `timestamp`, the time of its first block written as `2025-10-12 10:23:12` in UTC. A listing then tells what a file holds without reading it.
 
-  Google Cloud Storage only, since it writes object metadata without rewriting the file. Each file is streamed through a zstd decoder into a byte counter and dropped as it decodes, so memory stays flat whatever the file size, and `--parallelism` (32 by default) sets how many files are read at once. Files that a previous run already annotated are skipped straight from the listing, which carries their metadata, so a rerun over a mostly-done store costs one listing and nothing else; `--overwrite` recomputes them. A plain `.dbin` file is never read at all, its object size is already the answer. `--start-block` and `--stop-block` bound the listing service-side, `--dry-run` reports what would be annotated without reading anything.
+  Google Cloud Storage only: no other backend keeps custom object metadata a listing reads back, so elsewhere nothing is written and nothing changes. The size is counted as the bundle streams to the store, and the first block's time is read from the head of the first one-block file, far enough to reach the timestamp field and no further, so a chain with large blocks costs no more than one with small blocks. An annotation that cannot be written never fails the merge: the bundle is written and correct, only its description is missing, and `firecore tools annotate-merged-blocks` fills that back in.
 
-  Reads and metadata writes are both pinned to the generation and metageneration the listing returned, so a file the merger rewrites mid-run is reported as failed rather than annotated with the size of a version that is gone. `--grpc` switches to the Cloud Storage gRPC API, which on GKE takes the DirectPath route straight to the storage backend, spread over `--grpc-connection-pool` connections (one per 32 of `--parallelism` by default).
+- Added `firecore tools annotate-merged-blocks <gs-store-url>`, which writes those same three entries on merged-blocks files written before the merger did it. Google Cloud Storage only, for the same reason.
+
+  Each file is streamed through a zstd decoder and dropped as it decodes, one block at a time into a scratch buffer reused from block to block and from file to file, so memory stays flat whatever the block size; of the first block only the head is looked at, far enough to reach its timestamp. Only the block's metadata fields are ever decoded, its chain-specific payload being skipped, so no chain block type is needed. `--parallelism` (32 by default) sets how many files are read at once.
+
+  Files a previous run already annotated with all three entries are skipped straight from the listing, which carries their metadata, so a rerun over a mostly-done store costs one listing and nothing else; `--overwrite` recomputes them. `--start-block` and `--stop-block` bound the listing service-side, `--dry-run` reports what would be annotated without reading anything.
+
+  Reads and metadata writes are both pinned to the generation and metageneration the listing returned, so a file the merger rewrites mid-run is reported as failed rather than annotated with values from a version that is gone. `--grpc` switches to the Cloud Storage gRPC API, which on GKE takes the DirectPath route straight to the storage backend, spread over `--grpc-connection-pool` connections (one per 32 of `--parallelism` by default).
 
   The store URL takes the same two query parameters `dstore` reads off a `gs://` URL: `?project=` bills the reads to that project on a requester-pays bucket, and `?client_protocol=grpc` selects the same transport as `--grpc`. Setting a project turns DirectPath off, since DirectPath does not carry the `x-goog-user-project` header requester-pays billing needs.
+
+- Added `firecore tools stats-merged-blocks <gs-store-url>`, which reports a merged-blocks store's total compressed and uncompressed size, block count, compression ratio and bytes per block, broken down by month and totalled over `--start-block` to `--stop-block`.
+
+  Nothing is downloaded: every number comes from the three metadata entries above, which come back with the listing, so the whole report costs one listing however large the range is. Files missing any of the three are counted and reported, and contribute to nothing. Google Cloud Storage only, where the annotation lives.
 
 - `firecore tools substreams purge`, `prune-states` and `prune-outputs` all skip any module folder carrying a `DO_NOT_PRUNE` file at its root, next to the `last_used*.zst` markers, and report how many folders that spared.
 

--- a/block_timestamp.go
+++ b/block_timestamp.go
@@ -1,0 +1,78 @@
+package firecore
+
+import (
+	"fmt"
+	"time"
+
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// BlockTimestampPeekSize is how many bytes of a serialized pbbstream.Block are enough to reach
+// its timestamp. The fields before it are number (varint, ~2 bytes), id and parent_id (strings,
+// ~34 bytes each), so the timestamp always lands well within this, long before the payload.
+// Reading only this much keeps a block of any size out of memory.
+const BlockTimestampPeekSize = 512
+
+// ExtractBlockTimestamp scans the head of a serialized pbbstream.Block field by field, returning
+// as soon as it reaches field 4, the timestamp. The bytes after it, the chain-specific payload
+// included, never need to be read.
+func ExtractBlockTimestamp(data []byte) (time.Time, error) {
+	for len(data) > 0 {
+		num, typ, n := protowire.ConsumeTag(data)
+		if n < 0 {
+			return time.Time{}, protowire.ParseError(n)
+		}
+		data = data[n:]
+
+		if num == 4 && typ == protowire.BytesType { // field 4 = timestamp (embedded message)
+			tsBytes, n := protowire.ConsumeBytes(data)
+			if n < 0 {
+				return time.Time{}, protowire.ParseError(n)
+			}
+			return decodeProtoTimestamp(tsBytes)
+		}
+
+		n = protowire.ConsumeFieldValue(num, typ, data)
+		if n < 0 {
+			return time.Time{}, protowire.ParseError(n)
+		}
+		data = data[n:]
+	}
+	return time.Time{}, fmt.Errorf("timestamp field not found in first %d bytes of block", BlockTimestampPeekSize)
+}
+
+// decodeProtoTimestamp decodes a serialized google.protobuf.Timestamp (seconds=1, nanos=2).
+func decodeProtoTimestamp(data []byte) (time.Time, error) {
+	var seconds int64
+	var nanos int32
+	for len(data) > 0 {
+		num, typ, n := protowire.ConsumeTag(data)
+		if n < 0 {
+			return time.Time{}, protowire.ParseError(n)
+		}
+		data = data[n:]
+		switch {
+		case num == 1 && typ == protowire.VarintType:
+			v, n := protowire.ConsumeVarint(data)
+			if n < 0 {
+				return time.Time{}, protowire.ParseError(n)
+			}
+			seconds = int64(v)
+			data = data[n:]
+		case num == 2 && typ == protowire.VarintType:
+			v, n := protowire.ConsumeVarint(data)
+			if n < 0 {
+				return time.Time{}, protowire.ParseError(n)
+			}
+			nanos = int32(v)
+			data = data[n:]
+		default:
+			n = protowire.ConsumeFieldValue(num, typ, data)
+			if n < 0 {
+				return time.Time{}, protowire.ParseError(n)
+			}
+			data = data[n:]
+		}
+	}
+	return time.Unix(seconds, int64(nanos)).UTC(), nil
+}

--- a/cmd/tools/mergeblock/merged_blocks_gs.go
+++ b/cmd/tools/mergeblock/merged_blocks_gs.go
@@ -1,0 +1,171 @@
+package mergeblock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	firecore "github.com/streamingfast/firehose-core"
+	"go.uber.org/zap"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+	"google.golang.org/api/option/internaloption"
+)
+
+// The custom object metadata entries the merger writes on a merged-blocks file, which
+// 'annotate-merged-blocks' backfills and 'stats-merged-blocks' reports from.
+const (
+	dataSizeMetadataKey     = firecore.MergedBlocksDataSizeMetadataKey
+	itemCountMetadataKey    = firecore.MergedBlocksItemCountMetadataKey
+	timestampMetadataKey    = firecore.MergedBlocksTimestampMetadataKey
+	timestampMetadataLayout = firecore.MergedBlocksTimestampLayout
+)
+
+// mergedBlocksFileRE matches a merged-blocks object base name, '0000012300.dbin.zst', with the
+// compression suffix optional.
+var mergedBlocksFileRE = regexp.MustCompile(`^(\d{10})\.dbin(\.zst)?$`)
+
+// gsTarget is what the store URL says: where to look, plus the two query parameters dstore
+// reads off a 'gs://' URL, so the same URL means the same thing here as it does anywhere else
+// in the stack.
+type gsTarget struct {
+	bucket string
+	prefix string
+	// userProject bills the reads to that project, for a requester-pays bucket ('?project=').
+	userProject string
+	// grpc is '?client_protocol=grpc', which selects the same transport as --grpc.
+	grpc bool
+}
+
+func parseGSURL(storeURL string) (gsTarget, error) {
+	parsed, err := url.Parse(storeURL)
+	if err != nil {
+		return gsTarget{}, fmt.Errorf("invalid store url %q: %w", storeURL, err)
+	}
+	if parsed.Scheme != "gs" {
+		return gsTarget{}, fmt.Errorf("store url %q must be a Google Cloud Storage url (gs://bucket/path), this command works on object metadata which only that backend supports", storeURL)
+	}
+	if parsed.Host == "" {
+		return gsTarget{}, fmt.Errorf("store url %q has no bucket", storeURL)
+	}
+
+	prefix := strings.Trim(parsed.Path, "/")
+	if prefix != "" {
+		prefix += "/"
+	}
+
+	query := parsed.Query()
+	return gsTarget{
+		bucket:      parsed.Host,
+		prefix:      prefix,
+		userProject: query.Get("project"),
+		grpc:        query.Get("client_protocol") == "grpc",
+	}, nil
+}
+
+func newGSClient(ctx context.Context, target gsTarget, useGRPC bool, connectionPool int, logger *zap.Logger) (*storage.Client, error) {
+	if !useGRPC {
+		return storage.NewClient(ctx)
+	}
+
+	opts := []option.ClientOption{option.WithGRPCConnectionPool(connectionPool)}
+	if target.userProject != "" {
+		// DirectPath goes straight to the storage backend, which does not honour the
+		// x-goog-user-project gRPC metadata header requester-pays billing needs. Turning it
+		// off keeps gRPC while routing through the Google Front End, which does enforce it.
+		opts = append(opts, internaloption.EnableDirectPath(false))
+		logger.Warn("DirectPath disabled: it does not carry the requester-pays project, which this store url sets",
+			zap.String("project", target.userProject),
+		)
+	}
+	return storage.NewGRPCClient(ctx, opts...)
+}
+
+// grpcConnectionPool spreads the readers over several gRPC connections: a single HTTP/2
+// connection multiplexes every stream over one TCP socket, which caps throughput well before
+// a wide worker pool does.
+func grpcConnectionPool(requested, parallelism int) int {
+	if requested > 0 {
+		return requested
+	}
+	pool := (parallelism + 31) / 32
+	if pool < 1 {
+		return 1
+	}
+	if pool > 16 {
+		return 16
+	}
+	return pool
+}
+
+func bucketHandle(client *storage.Client, target gsTarget) *storage.BucketHandle {
+	bucket := client.Bucket(target.bucket)
+	if target.userProject != "" {
+		bucket = bucket.UserProject(target.userProject)
+	}
+	return bucket
+}
+
+// mergedBlocksObject is one merged-blocks file as the listing returned it.
+type mergedBlocksObject struct {
+	attrs *storage.ObjectAttrs
+	// lowBlockNum is the first block of the bundle, the number the file is named after.
+	lowBlockNum uint64
+	// compressed is false for a plain '.dbin' file.
+	compressed bool
+}
+
+// walkMergedBlocks lists the merged-blocks files of the store between startBlock and stopBlock,
+// calling onObject for each. Both bounds are pushed to the service as listing offsets: names are
+// zero-padded to a fixed width, so the lexicographic order the listing walks is the block order.
+// stopBlock is exclusive and 0 means no upper bound. Anything under the prefix that is not a
+// merged-blocks file is ignored.
+func walkMergedBlocks(
+	ctx context.Context,
+	bucket *storage.BucketHandle,
+	prefix string,
+	startBlock, stopBlock uint64,
+	attrSelection []string,
+	onObject func(mergedBlocksObject) error,
+) error {
+	query := &storage.Query{Prefix: prefix, Delimiter: "/"}
+	if startBlock > 0 {
+		query.StartOffset = prefix + fmt.Sprintf("%010d", startBlock)
+	}
+	if stopBlock > 0 {
+		query.EndOffset = prefix + fmt.Sprintf("%010d", stopBlock)
+	}
+	if err := query.SetAttrSelection(attrSelection); err != nil {
+		return fmt.Errorf("selecting listing attributes: %w", err)
+	}
+
+	it := bucket.Objects(ctx, query)
+	for {
+		attrs, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		match := mergedBlocksFileRE.FindStringSubmatch(strings.TrimPrefix(attrs.Name, prefix))
+		if match == nil {
+			continue
+		}
+		lowBlockNum, err := strconv.ParseUint(match[1], 10, 64)
+		if err != nil {
+			continue
+		}
+
+		object := mergedBlocksObject{attrs: attrs, lowBlockNum: lowBlockNum, compressed: match[2] == ".zst"}
+		if err := onObject(object); err != nil {
+			return err
+		}
+	}
+}

--- a/cmd/tools/mergeblock/merged_blocks_gs_test.go
+++ b/cmd/tools/mergeblock/merged_blocks_gs_test.go
@@ -1,0 +1,75 @@
+package mergeblock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGSURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		expect    gsTarget
+		expectErr string
+	}{
+		{name: "bucket and folder", url: "gs://example-bucket/eth-mainnet/merged", expect: gsTarget{bucket: "example-bucket", prefix: "eth-mainnet/merged/"}},
+		{name: "trailing slash", url: "gs://example-bucket/eth-mainnet/merged/", expect: gsTarget{bucket: "example-bucket", prefix: "eth-mainnet/merged/"}},
+		{name: "bucket root", url: "gs://example-bucket", expect: gsTarget{bucket: "example-bucket"}},
+		{name: "requester pays project", url: "gs://example-bucket/merged?project=my-project", expect: gsTarget{bucket: "example-bucket", prefix: "merged/", userProject: "my-project"}},
+		{name: "grpc client protocol", url: "gs://example-bucket/merged?client_protocol=grpc", expect: gsTarget{bucket: "example-bucket", prefix: "merged/", grpc: true}},
+		{name: "http client protocol", url: "gs://example-bucket/merged?client_protocol=http", expect: gsTarget{bucket: "example-bucket", prefix: "merged/"}},
+		{name: "both parameters", url: "gs://example-bucket/merged?project=my-project&client_protocol=grpc", expect: gsTarget{bucket: "example-bucket", prefix: "merged/", userProject: "my-project", grpc: true}},
+		{name: "local path refused", url: "/data/merged", expectErr: "must be a Google Cloud Storage url"},
+		{name: "s3 refused", url: "s3://example-bucket/merged", expectErr: "must be a Google Cloud Storage url"},
+		{name: "no bucket", url: "gs:///merged", expectErr: "has no bucket"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			target, err := parseGSURL(test.url)
+			if test.expectErr != "" {
+				require.ErrorContains(t, err, test.expectErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.expect, target)
+		})
+	}
+}
+
+func TestMergedBlocksFileRegex(t *testing.T) {
+	tests := []struct {
+		base      string
+		matches   bool
+		zstSuffix string
+	}{
+		{base: "0000012300.dbin.zst", matches: true, zstSuffix: ".zst"},
+		{base: "0000012300.dbin", matches: true, zstSuffix: ""},
+		{base: "0000012300.dbin.gz", matches: false},
+		{base: "123.dbin.zst", matches: false},
+		{base: "0000012300-0000012400.output.zst", matches: false},
+		{base: "substreams.spkg.zst", matches: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.base, func(t *testing.T) {
+			match := mergedBlocksFileRE.FindStringSubmatch(test.base)
+			if !test.matches {
+				assert.Nil(t, match)
+				return
+			}
+			require.NotNil(t, match)
+			assert.Equal(t, test.zstSuffix, match[2])
+		})
+	}
+}
+
+func TestGRPCConnectionPool(t *testing.T) {
+	assert.Equal(t, 7, grpcConnectionPool(7, 32))
+	assert.Equal(t, 1, grpcConnectionPool(0, 1))
+	assert.Equal(t, 1, grpcConnectionPool(0, 32))
+	assert.Equal(t, 2, grpcConnectionPool(0, 33))
+	assert.Equal(t, 16, grpcConnectionPool(0, 4096))
+}

--- a/cmd/tools/mergeblock/tools_annotate_merged_blocks.go
+++ b/cmd/tools/mergeblock/tools_annotate_merged_blocks.go
@@ -1,0 +1,448 @@
+package mergeblock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/dustin/go-humanize"
+	"github.com/klauspost/compress/zstd"
+	"github.com/spf13/cobra"
+	"github.com/streamingfast/cli"
+	"github.com/streamingfast/cli/sflags"
+	"github.com/streamingfast/firehose-core/cmd/tools/stylex"
+	"go.uber.org/zap"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+	"google.golang.org/api/option/internaloption"
+)
+
+// dataSizeMetadataKey is the custom object metadata entry this tool writes, holding the
+// decimal number of bytes the merged-blocks file holds once decompressed.
+const dataSizeMetadataKey = "datasize"
+
+// mergedBlocksFileRE matches a merged-blocks object base name, '0000012300.dbin.zst', with
+// the compression suffix optional: a plain '.dbin' file needs no read at all, its object
+// size is already the uncompressed size.
+var mergedBlocksFileRE = regexp.MustCompile(`^(\d{10})\.dbin(\.zst)?$`)
+
+func NewToolsAnnotateMergedBlocksCmd(rootLog *zap.Logger) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "annotate-merged-blocks <gs-store-url>",
+		Short: "Write each merged-blocks file's uncompressed size into its 'datasize' object metadata",
+		Long: cli.Dedent(`
+			Reads every merged-blocks file under the store URL, streams it through a zstd
+			decoder into a byte counter, and writes that count as the object's 'datasize'
+			custom metadata entry. Nothing is buffered: the decompressed bytes are counted
+			and dropped, so memory stays flat whatever the file size.
+
+			This only works on Google Cloud Storage ('gs://') because it sets object metadata
+			on files it does not rewrite.
+
+			The listing already carries each object's existing metadata, so files that were
+			annotated by a previous run are skipped without a single extra request: rerunning
+			over a store that is mostly done costs one listing and nothing else. --overwrite
+			recomputes them anyway.
+
+			Every file is read and updated under both its generation and its metageneration,
+			so a file rewritten by the merger while this runs is reported as failed rather
+			than annotated with a size taken from the version that is gone.
+
+			Running inside a GCP pod, --grpc is worth trying: it uses the Cloud Storage gRPC
+			API, which on GKE takes the DirectPath route to the storage backend and skips the
+			Google Front End entirely.
+
+			The store URL takes the same two query parameters dstore reads: '?project=' bills
+			the reads to that project on a requester-pays bucket, and '?client_protocol=grpc'
+			selects the same transport as --grpc. Requester-pays and DirectPath are mutually
+			exclusive, so setting a project turns DirectPath off and routes the gRPC traffic
+			through the Google Front End, which is the only side that enforces the billing.
+		`),
+		Example: cli.Dedent(`
+			# Annotate a whole merged-blocks store with 64 concurrent readers
+			firecore tools annotate-merged-blocks gs://example-bucket/eth-mainnet/merged --parallelism 64
+
+			# Annotate blocks 1000000 to 2000000 over gRPC, from a GKE pod
+			firecore tools annotate-merged-blocks gs://example-bucket/eth-mainnet/merged \
+			  --start-block 1000000 --stop-block 2000000 --grpc
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg := annotateConfig{
+				parallelism: sflags.MustGetInt(cmd, "parallelism"),
+				useGRPC:     sflags.MustGetBool(cmd, "grpc"),
+				connPool:    sflags.MustGetInt(cmd, "grpc-connection-pool"),
+				overwrite:   sflags.MustGetBool(cmd, "overwrite"),
+				dryRun:      sflags.MustGetBool(cmd, "dry-run"),
+				startBlock:  sflags.MustGetUint64(cmd, "start-block"),
+				stopBlock:   sflags.MustGetUint64(cmd, "stop-block"),
+			}
+			cmd.SilenceUsage = true
+			return runAnnotateMergedBlocks(cmd.Context(), args[0], cfg, rootLog)
+		},
+	}
+
+	cmd.Flags().Int("parallelism", 32, "Number of merged-blocks files read and annotated concurrently")
+	cmd.Flags().Bool("grpc", false, "Talk to Cloud Storage over its gRPC API instead of JSON/XML over HTTP")
+	cmd.Flags().Int("grpc-connection-pool", 0, "Number of gRPC connections to spread the work over, 0 derives one per 32 of --parallelism")
+	cmd.Flags().Bool("overwrite", false, "Recompute files that already carry a 'datasize' metadata entry")
+	cmd.Flags().BoolP("dry-run", "n", false, "Only report how many files would be annotated, reading none of them")
+	cmd.Flags().Uint64("start-block", 0, "Only annotate files whose first block is at or above this block")
+	cmd.Flags().Uint64("stop-block", 0, "Only annotate files whose first block is below this block, 0 for no upper bound")
+
+	return cmd
+}
+
+type annotateConfig struct {
+	parallelism int
+	useGRPC     bool
+	connPool    int
+	overwrite   bool
+	dryRun      bool
+	startBlock  uint64
+	stopBlock   uint64
+}
+
+type annotateStats struct {
+	listed       atomic.Int64
+	annotated    atomic.Int64
+	skipped      atomic.Int64
+	failed       atomic.Int64
+	compressed   atomic.Int64
+	uncompressed atomic.Int64
+}
+
+func runAnnotateMergedBlocks(ctx context.Context, storeURL string, cfg annotateConfig, logger *zap.Logger) error {
+	target, err := parseGSURL(storeURL)
+	if err != nil {
+		return err
+	}
+	cfg.useGRPC = cfg.useGRPC || target.grpc
+
+	if cfg.parallelism < 1 {
+		cfg.parallelism = 1
+	}
+	if cfg.stopBlock != 0 && cfg.stopBlock <= cfg.startBlock {
+		return fmt.Errorf("--stop-block %d must be above --start-block %d", cfg.stopBlock, cfg.startBlock)
+	}
+
+	client, err := newGSClient(ctx, target, cfg, logger)
+	if err != nil {
+		return fmt.Errorf("creating storage client: %w", err)
+	}
+	defer client.Close()
+
+	bucket := client.Bucket(target.bucket)
+	if target.userProject != "" {
+		bucket = bucket.UserProject(target.userProject)
+	}
+	prefix := target.prefix
+
+	fmt.Println(stylex.Title("Merged Blocks Data Size Annotation"))
+	fmt.Println(stylex.Dim(stylex.Separator(80)))
+	fmt.Println(stylex.Labelf("Store:       %s", storeURL))
+	fmt.Println(stylex.Labelf("Parallelism: %d", cfg.parallelism))
+	if cfg.useGRPC {
+		fmt.Println(stylex.Labelf("Transport:   gRPC (%d connection(s))", grpcConnectionPool(cfg)))
+	} else {
+		fmt.Println(stylex.Label("Transport:   HTTP"))
+	}
+	if cfg.dryRun {
+		fmt.Println(stylex.Warn("Dry run: nothing is read and no metadata is written"))
+	}
+	fmt.Println()
+
+	stats := &annotateStats{}
+	started := time.Now()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	stopProgress := startAnnotateProgress(ctx, stats, started, logger)
+
+	objects := make(chan *storage.ObjectAttrs, cfg.parallelism*2)
+
+	var workers sync.WaitGroup
+	for range cfg.parallelism {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			annotateWorker(ctx, bucket, prefix, cfg, objects, stats, logger)
+		}()
+	}
+
+	listErr := listMergedBlocks(ctx, bucket, prefix, cfg, stats, objects)
+	close(objects)
+	workers.Wait()
+	stopProgress()
+
+	elapsed := time.Since(started)
+	annotatedLabel := "Annotated:  "
+	if cfg.dryRun {
+		annotatedLabel = "Would annotate:"
+	}
+	fmt.Println(stylex.Valuef("%s %d file(s)", annotatedLabel, stats.annotated.Load()))
+	fmt.Println(stylex.Valuef("Skipped:     %d file(s) already carrying '%s'", stats.skipped.Load(), dataSizeMetadataKey))
+	fmt.Println(stylex.Valuef("Read:        %s compressed, %s uncompressed", humanize.Bytes(uint64(stats.compressed.Load())), humanize.Bytes(uint64(stats.uncompressed.Load()))))
+	fmt.Println(stylex.Valuef("Elapsed:     %s", elapsed.Round(time.Second)))
+
+	if listErr != nil {
+		fmt.Println(stylex.Error("✗ listing interrupted"))
+		return fmt.Errorf("listing %s: %w", storeURL, listErr)
+	}
+	if failed := stats.failed.Load(); failed > 0 {
+		fmt.Println(stylex.Errorf("✗ %d file(s) could not be annotated", failed))
+		return fmt.Errorf("%d file(s) could not be annotated", failed)
+	}
+	fmt.Println(stylex.Success("✓"))
+	return nil
+}
+
+// listMergedBlocks feeds the workers, reading names, sizes, generations and existing metadata
+// straight out of the listing so an already-annotated file costs nothing beyond its listing row.
+func listMergedBlocks(ctx context.Context, bucket *storage.BucketHandle, prefix string, cfg annotateConfig, stats *annotateStats, objects chan<- *storage.ObjectAttrs) error {
+	query := &storage.Query{Prefix: prefix, Delimiter: "/"}
+	if cfg.startBlock > 0 {
+		query.StartOffset = prefix + fmt.Sprintf("%010d", cfg.startBlock)
+	}
+	if cfg.stopBlock > 0 {
+		query.EndOffset = prefix + fmt.Sprintf("%010d", cfg.stopBlock)
+	}
+	if err := query.SetAttrSelection([]string{"Name", "Size", "Generation", "Metageneration", "Metadata"}); err != nil {
+		return fmt.Errorf("selecting listing attributes: %w", err)
+	}
+
+	it := bucket.Objects(ctx, query)
+	for {
+		attrs, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		stats.listed.Add(1)
+		select {
+		case objects <- attrs:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func annotateWorker(ctx context.Context, bucket *storage.BucketHandle, prefix string, cfg annotateConfig, objects <-chan *storage.ObjectAttrs, stats *annotateStats, logger *zap.Logger) {
+	// One decoder per worker, reused across files and told to decode on this goroutine only:
+	// the worker pool already provides the parallelism, and a low-memory decoder keeps the
+	// window allocation bounded whatever the file size.
+	decoder, err := zstd.NewReader(nil, zstd.WithDecoderConcurrency(1), zstd.WithDecoderLowmem(true))
+	if err != nil {
+		logger.Error("cannot create zstd decoder", zap.Error(err))
+		stats.failed.Add(1)
+		return
+	}
+	defer decoder.Close()
+
+	for attrs := range objects {
+		if ctx.Err() != nil {
+			return
+		}
+
+		base := strings.TrimPrefix(attrs.Name, prefix)
+		match := mergedBlocksFileRE.FindStringSubmatch(base)
+		if match == nil {
+			continue
+		}
+		if !cfg.overwrite {
+			if _, found := attrs.Metadata[dataSizeMetadataKey]; found {
+				stats.skipped.Add(1)
+				continue
+			}
+		}
+		if cfg.dryRun {
+			stats.annotated.Add(1)
+			continue
+		}
+
+		if err := annotateOne(ctx, bucket, attrs, match[2] == ".zst", decoder, stats); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			stats.failed.Add(1)
+			logger.Warn("cannot annotate merged-blocks file", zap.String("file", attrs.Name), zap.Error(err))
+			continue
+		}
+		stats.annotated.Add(1)
+	}
+}
+
+func annotateOne(ctx context.Context, bucket *storage.BucketHandle, attrs *storage.ObjectAttrs, compressed bool, decoder *zstd.Decoder, stats *annotateStats) error {
+	dataSize := attrs.Size
+	if compressed {
+		size, err := uncompressedSize(ctx, bucket.Object(attrs.Name).Generation(attrs.Generation), decoder)
+		if err != nil {
+			return err
+		}
+		dataSize = size
+		stats.compressed.Add(attrs.Size)
+	}
+	stats.uncompressed.Add(dataSize)
+
+	metadata := make(map[string]string, len(attrs.Metadata)+1)
+	maps.Copy(metadata, attrs.Metadata)
+	metadata[dataSizeMetadataKey] = strconv.FormatInt(dataSize, 10)
+
+	conditions := storage.Conditions{GenerationMatch: attrs.Generation, MetagenerationMatch: attrs.Metageneration}
+	_, err := bucket.Object(attrs.Name).If(conditions).Update(ctx, storage.ObjectAttrsToUpdate{Metadata: metadata})
+	if err != nil {
+		return fmt.Errorf("writing metadata: %w", err)
+	}
+	return nil
+}
+
+// uncompressedSize streams the object through the decoder and counts what comes out. The
+// decoded bytes go to io.Discard as they are produced, so a file of any size costs only the
+// decoder's window.
+func uncompressedSize(ctx context.Context, object *storage.ObjectHandle, decoder *zstd.Decoder) (int64, error) {
+	reader, err := object.NewReader(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("opening object: %w", err)
+	}
+	defer reader.Close()
+
+	return countDecompressed(decoder, reader)
+}
+
+// countDecompressed decodes everything the reader holds and returns how many bytes came out,
+// dropping them as they are produced.
+func countDecompressed(decoder *zstd.Decoder, reader io.Reader) (int64, error) {
+	if err := decoder.Reset(reader); err != nil {
+		return 0, fmt.Errorf("resetting decoder: %w", err)
+	}
+	// Release the reference to the reader once counted, the decoder outlives this file.
+	defer decoder.Reset(nil)
+
+	size, err := io.Copy(io.Discard, decoder)
+	if err != nil {
+		return 0, fmt.Errorf("decompressing: %w", err)
+	}
+	return size, nil
+}
+
+func startAnnotateProgress(ctx context.Context, stats *annotateStats, started time.Time, logger *zap.Logger) (stop func()) {
+	ticker := time.NewTicker(10 * time.Second)
+	quit := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-quit:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				elapsed := time.Since(started)
+				annotated := stats.annotated.Load()
+				logger.Info("annotating merged-blocks files",
+					zap.Int64("listed", stats.listed.Load()),
+					zap.Int64("annotated", annotated),
+					zap.Int64("skipped", stats.skipped.Load()),
+					zap.Int64("failed", stats.failed.Load()),
+					zap.String("uncompressed", humanize.Bytes(uint64(stats.uncompressed.Load()))),
+					zap.Float64("files_per_second", float64(annotated)/elapsed.Seconds()),
+				)
+			}
+		}
+	}()
+
+	return func() {
+		ticker.Stop()
+		close(quit)
+		<-done
+	}
+}
+
+func newGSClient(ctx context.Context, target gsTarget, cfg annotateConfig, logger *zap.Logger) (*storage.Client, error) {
+	if !cfg.useGRPC {
+		return storage.NewClient(ctx)
+	}
+
+	opts := []option.ClientOption{option.WithGRPCConnectionPool(grpcConnectionPool(cfg))}
+	if target.userProject != "" {
+		// DirectPath goes straight to the storage backend, which does not honour the
+		// x-goog-user-project gRPC metadata header requester-pays billing needs. Turning it
+		// off keeps gRPC while routing through the Google Front End, which does enforce it.
+		opts = append(opts, internaloption.EnableDirectPath(false))
+		logger.Warn("DirectPath disabled: it does not carry the requester-pays project, which this store url sets",
+			zap.String("project", target.userProject),
+		)
+	}
+	return storage.NewGRPCClient(ctx, opts...)
+}
+
+// grpcConnectionPool spreads the readers over several gRPC connections: a single HTTP/2
+// connection multiplexes every stream over one TCP socket, which caps throughput well before
+// a wide worker pool does.
+func grpcConnectionPool(cfg annotateConfig) int {
+	if cfg.connPool > 0 {
+		return cfg.connPool
+	}
+	pool := (cfg.parallelism + 31) / 32
+	if pool < 1 {
+		return 1
+	}
+	if pool > 16 {
+		return 16
+	}
+	return pool
+}
+
+// gsTarget is what the store URL says: where to look, plus the two query parameters dstore
+// reads off a 'gs://' URL, so the same URL means the same thing here as it does anywhere else
+// in the stack.
+type gsTarget struct {
+	bucket string
+	prefix string
+	// userProject bills reads to that project, for a requester-pays bucket ('?project=').
+	userProject string
+	// grpc is '?client_protocol=grpc', which selects the same transport as --grpc.
+	grpc bool
+}
+
+func parseGSURL(storeURL string) (gsTarget, error) {
+	parsed, err := url.Parse(storeURL)
+	if err != nil {
+		return gsTarget{}, fmt.Errorf("invalid store url %q: %w", storeURL, err)
+	}
+	if parsed.Scheme != "gs" {
+		return gsTarget{}, fmt.Errorf("store url %q must be a Google Cloud Storage url (gs://bucket/path), this tool writes object metadata which only that backend supports", storeURL)
+	}
+	if parsed.Host == "" {
+		return gsTarget{}, fmt.Errorf("store url %q has no bucket", storeURL)
+	}
+
+	prefix := strings.Trim(parsed.Path, "/")
+	if prefix != "" {
+		prefix += "/"
+	}
+
+	query := parsed.Query()
+	return gsTarget{
+		bucket:      parsed.Host,
+		prefix:      prefix,
+		userProject: query.Get("project"),
+		grpc:        query.Get("client_protocol") == "grpc",
+	}, nil
+}

--- a/cmd/tools/mergeblock/tools_annotate_merged_blocks.go
+++ b/cmd/tools/mergeblock/tools_annotate_merged_blocks.go
@@ -2,14 +2,11 @@ package mergeblock
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
 	"maps"
-	"net/url"
-	"regexp"
-	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -20,43 +17,50 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/streamingfast/cli"
 	"github.com/streamingfast/cli/sflags"
+	"github.com/streamingfast/dbin"
+	firecore "github.com/streamingfast/firehose-core"
 	"github.com/streamingfast/firehose-core/cmd/tools/stylex"
 	"go.uber.org/zap"
-	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
-	"google.golang.org/api/option/internaloption"
 )
 
-// dataSizeMetadataKey is the custom object metadata entry this tool writes, holding the
-// decimal number of bytes the merged-blocks file holds once decompressed.
-const dataSizeMetadataKey = "datasize"
-
-// mergedBlocksFileRE matches a merged-blocks object base name, '0000012300.dbin.zst', with
-// the compression suffix optional: a plain '.dbin' file needs no read at all, its object
-// size is already the uncompressed size.
-var mergedBlocksFileRE = regexp.MustCompile(`^(\d{10})\.dbin(\.zst)?$`)
+// scanScratchBufferSize is the chunk a worker reads a block in. Big enough that a large block
+// takes few reads, small enough that a wide --parallelism stays cheap: at the default of 32
+// workers these buffers add up to 16 MiB.
+const scanScratchBufferSize = 512 * 1024
 
 func NewToolsAnnotateMergedBlocksCmd(rootLog *zap.Logger) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "annotate-merged-blocks <gs-store-url>",
-		Short: "Write each merged-blocks file's uncompressed size into its 'datasize' object metadata",
+		Short: "Record each merged-blocks file's size, block count and first block time in its object metadata",
 		Long: cli.Dedent(`
 			Reads every merged-blocks file under the store URL, streams it through a zstd
-			decoder into a byte counter, and writes that count as the object's 'datasize'
-			custom metadata entry. Nothing is buffered: the decompressed bytes are counted
-			and dropped, so memory stays flat whatever the file size.
+			decoder, and writes three custom metadata entries on the object:
+
+			  datasize   the file's size once decompressed, in bytes
+			  itemcount  the number of blocks the file holds
+			  timestamp  the time of the file's first block, '2025-10-12 10:23:12' in UTC
+
+			'firecore tools stats-merged-blocks' then reports on a whole store from these
+			entries, reading them out of a listing without downloading a single file again.
+
+			No block is ever held: each one is read into a scratch buffer that is reused from
+			block to block and from file to file, and dropped, so memory stays flat whatever
+			the block size. Of the first block only the head is looked at, far enough to reach
+			its timestamp field, and only the block's metadata fields are decoded, its
+			chain-specific payload being skipped, so this works on any chain's merged blocks
+			without knowing the chain's block type.
 
 			This only works on Google Cloud Storage ('gs://') because it sets object metadata
 			on files it does not rewrite.
 
-			The listing already carries each object's existing metadata, so files that were
-			annotated by a previous run are skipped without a single extra request: rerunning
-			over a store that is mostly done costs one listing and nothing else. --overwrite
+			The listing already carries each object's existing metadata, so files that already
+			carry all three entries are skipped without a single extra request: rerunning over
+			a store that is mostly done costs one listing and nothing else. --overwrite
 			recomputes them anyway.
 
 			Every file is read and updated under both its generation and its metageneration,
 			so a file rewritten by the merger while this runs is reported as failed rather
-			than annotated with a size taken from the version that is gone.
+			than annotated with values taken from the version that is gone.
 
 			Running inside a GCP pod, --grpc is worth trying: it uses the Cloud Storage gRPC
 			API, which on GKE takes the DirectPath route to the storage backend and skips the
@@ -95,7 +99,7 @@ func NewToolsAnnotateMergedBlocksCmd(rootLog *zap.Logger) *cobra.Command {
 	cmd.Flags().Int("parallelism", 32, "Number of merged-blocks files read and annotated concurrently")
 	cmd.Flags().Bool("grpc", false, "Talk to Cloud Storage over its gRPC API instead of JSON/XML over HTTP")
 	cmd.Flags().Int("grpc-connection-pool", 0, "Number of gRPC connections to spread the work over, 0 derives one per 32 of --parallelism")
-	cmd.Flags().Bool("overwrite", false, "Recompute files that already carry a 'datasize' metadata entry")
+	cmd.Flags().Bool("overwrite", false, "Recompute files that already carry all three metadata entries")
 	cmd.Flags().BoolP("dry-run", "n", false, "Only report how many files would be annotated, reading none of them")
 	cmd.Flags().Uint64("start-block", 0, "Only annotate files whose first block is at or above this block")
 	cmd.Flags().Uint64("stop-block", 0, "Only annotate files whose first block is below this block, 0 for no upper bound")
@@ -118,6 +122,7 @@ type annotateStats struct {
 	annotated    atomic.Int64
 	skipped      atomic.Int64
 	failed       atomic.Int64
+	blocks       atomic.Int64
 	compressed   atomic.Int64
 	uncompressed atomic.Int64
 }
@@ -136,24 +141,21 @@ func runAnnotateMergedBlocks(ctx context.Context, storeURL string, cfg annotateC
 		return fmt.Errorf("--stop-block %d must be above --start-block %d", cfg.stopBlock, cfg.startBlock)
 	}
 
-	client, err := newGSClient(ctx, target, cfg, logger)
+	connectionPool := grpcConnectionPool(cfg.connPool, cfg.parallelism)
+	client, err := newGSClient(ctx, target, cfg.useGRPC, connectionPool, logger)
 	if err != nil {
 		return fmt.Errorf("creating storage client: %w", err)
 	}
 	defer client.Close()
 
-	bucket := client.Bucket(target.bucket)
-	if target.userProject != "" {
-		bucket = bucket.UserProject(target.userProject)
-	}
-	prefix := target.prefix
+	bucket := bucketHandle(client, target)
 
-	fmt.Println(stylex.Title("Merged Blocks Data Size Annotation"))
+	fmt.Println(stylex.Title("Merged Blocks Annotation"))
 	fmt.Println(stylex.Dim(stylex.Separator(80)))
 	fmt.Println(stylex.Labelf("Store:       %s", storeURL))
 	fmt.Println(stylex.Labelf("Parallelism: %d", cfg.parallelism))
 	if cfg.useGRPC {
-		fmt.Println(stylex.Labelf("Transport:   gRPC (%d connection(s))", grpcConnectionPool(cfg)))
+		fmt.Println(stylex.Labelf("Transport:   gRPC (%d connection(s))", connectionPool))
 	} else {
 		fmt.Println(stylex.Label("Transport:   HTTP"))
 	}
@@ -170,31 +172,41 @@ func runAnnotateMergedBlocks(ctx context.Context, storeURL string, cfg annotateC
 
 	stopProgress := startAnnotateProgress(ctx, stats, started, logger)
 
-	objects := make(chan *storage.ObjectAttrs, cfg.parallelism*2)
+	objects := make(chan mergedBlocksObject, cfg.parallelism*2)
 
 	var workers sync.WaitGroup
 	for range cfg.parallelism {
 		workers.Add(1)
 		go func() {
 			defer workers.Done()
-			annotateWorker(ctx, bucket, prefix, cfg, objects, stats, logger)
+			annotateWorker(ctx, bucket, cfg, objects, stats, logger)
 		}()
 	}
 
-	listErr := listMergedBlocks(ctx, bucket, prefix, cfg, stats, objects)
+	listErr := walkMergedBlocks(ctx, bucket, target.prefix, cfg.startBlock, cfg.stopBlock,
+		[]string{"Name", "Size", "Generation", "Metageneration", "Metadata"},
+		func(object mergedBlocksObject) error {
+			stats.listed.Add(1)
+			select {
+			case objects <- object:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	)
 	close(objects)
 	workers.Wait()
 	stopProgress()
 
-	elapsed := time.Since(started)
 	annotatedLabel := "Annotated:  "
 	if cfg.dryRun {
 		annotatedLabel = "Would annotate:"
 	}
-	fmt.Println(stylex.Valuef("%s %d file(s)", annotatedLabel, stats.annotated.Load()))
-	fmt.Println(stylex.Valuef("Skipped:     %d file(s) already carrying '%s'", stats.skipped.Load(), dataSizeMetadataKey))
+	fmt.Println(stylex.Valuef("%s %d file(s), %s block(s)", annotatedLabel, stats.annotated.Load(), humanize.Comma(stats.blocks.Load())))
+	fmt.Println(stylex.Valuef("Skipped:     %d file(s) already carrying all three entries", stats.skipped.Load()))
 	fmt.Println(stylex.Valuef("Read:        %s compressed, %s uncompressed", humanize.Bytes(uint64(stats.compressed.Load())), humanize.Bytes(uint64(stats.uncompressed.Load()))))
-	fmt.Println(stylex.Valuef("Elapsed:     %s", elapsed.Round(time.Second)))
+	fmt.Println(stylex.Valuef("Elapsed:     %s", time.Since(started).Round(time.Second)))
 
 	if listErr != nil {
 		fmt.Println(stylex.Error("✗ listing interrupted"))
@@ -208,40 +220,7 @@ func runAnnotateMergedBlocks(ctx context.Context, storeURL string, cfg annotateC
 	return nil
 }
 
-// listMergedBlocks feeds the workers, reading names, sizes, generations and existing metadata
-// straight out of the listing so an already-annotated file costs nothing beyond its listing row.
-func listMergedBlocks(ctx context.Context, bucket *storage.BucketHandle, prefix string, cfg annotateConfig, stats *annotateStats, objects chan<- *storage.ObjectAttrs) error {
-	query := &storage.Query{Prefix: prefix, Delimiter: "/"}
-	if cfg.startBlock > 0 {
-		query.StartOffset = prefix + fmt.Sprintf("%010d", cfg.startBlock)
-	}
-	if cfg.stopBlock > 0 {
-		query.EndOffset = prefix + fmt.Sprintf("%010d", cfg.stopBlock)
-	}
-	if err := query.SetAttrSelection([]string{"Name", "Size", "Generation", "Metageneration", "Metadata"}); err != nil {
-		return fmt.Errorf("selecting listing attributes: %w", err)
-	}
-
-	it := bucket.Objects(ctx, query)
-	for {
-		attrs, err := it.Next()
-		if errors.Is(err, iterator.Done) {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-
-		stats.listed.Add(1)
-		select {
-		case objects <- attrs:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-}
-
-func annotateWorker(ctx context.Context, bucket *storage.BucketHandle, prefix string, cfg annotateConfig, objects <-chan *storage.ObjectAttrs, stats *annotateStats, logger *zap.Logger) {
+func annotateWorker(ctx context.Context, bucket *storage.BucketHandle, cfg annotateConfig, objects <-chan mergedBlocksObject, stats *annotateStats, logger *zap.Logger) {
 	// One decoder per worker, reused across files and told to decode on this goroutine only:
 	// the worker pool already provides the parallelism, and a low-memory decoder keeps the
 	// window allocation bounded whatever the file size.
@@ -253,91 +232,186 @@ func annotateWorker(ctx context.Context, bucket *storage.BucketHandle, prefix st
 	}
 	defer decoder.Close()
 
-	for attrs := range objects {
+	// One scratch buffer per worker, reused for every block of every file it handles.
+	scratch := make([]byte, scanScratchBufferSize)
+
+	for object := range objects {
 		if ctx.Err() != nil {
 			return
 		}
 
-		base := strings.TrimPrefix(attrs.Name, prefix)
-		match := mergedBlocksFileRE.FindStringSubmatch(base)
-		if match == nil {
+		if !cfg.overwrite && isAnnotated(object.attrs.Metadata) {
+			stats.skipped.Add(1)
 			continue
-		}
-		if !cfg.overwrite {
-			if _, found := attrs.Metadata[dataSizeMetadataKey]; found {
-				stats.skipped.Add(1)
-				continue
-			}
 		}
 		if cfg.dryRun {
 			stats.annotated.Add(1)
 			continue
 		}
 
-		if err := annotateOne(ctx, bucket, attrs, match[2] == ".zst", decoder, stats); err != nil {
+		if err := annotateOne(ctx, bucket, object, decoder, scratch, stats); err != nil {
 			if ctx.Err() != nil {
 				return
 			}
 			stats.failed.Add(1)
-			logger.Warn("cannot annotate merged-blocks file", zap.String("file", attrs.Name), zap.Error(err))
+			logger.Warn("cannot annotate merged-blocks file", zap.String("file", object.attrs.Name), zap.Error(err))
 			continue
 		}
 		stats.annotated.Add(1)
 	}
 }
 
-func annotateOne(ctx context.Context, bucket *storage.BucketHandle, attrs *storage.ObjectAttrs, compressed bool, decoder *zstd.Decoder, stats *annotateStats) error {
-	dataSize := attrs.Size
-	if compressed {
-		size, err := uncompressedSize(ctx, bucket.Object(attrs.Name).Generation(attrs.Generation), decoder)
-		if err != nil {
-			return err
+// isAnnotated reports whether a previous run left all three entries on the object; a file
+// carrying only some of them is read again so they always describe the same version of it.
+func isAnnotated(metadata map[string]string) bool {
+	for _, key := range []string{dataSizeMetadataKey, itemCountMetadataKey, timestampMetadataKey} {
+		if _, found := metadata[key]; !found {
+			return false
 		}
-		dataSize = size
-		stats.compressed.Add(attrs.Size)
 	}
-	stats.uncompressed.Add(dataSize)
+	return true
+}
 
-	metadata := make(map[string]string, len(attrs.Metadata)+1)
+func annotateOne(ctx context.Context, bucket *storage.BucketHandle, object mergedBlocksObject, decoder *zstd.Decoder, scratch []byte, stats *annotateStats) error {
+	attrs := object.attrs
+
+	// Pin the read to the generation the listing returned, so all three values describe one
+	// and the same version of the file.
+	reader, err := bucket.Object(attrs.Name).Generation(attrs.Generation).NewReader(ctx)
+	if err != nil {
+		return fmt.Errorf("opening object: %w", err)
+	}
+	defer reader.Close()
+
+	var source io.Reader = reader
+	if object.compressed {
+		if err := decoder.Reset(reader); err != nil {
+			return fmt.Errorf("resetting decoder: %w", err)
+		}
+		// Release the reference to the reader once read, the decoder outlives this file.
+		defer decoder.Reset(nil)
+		source = decoder
+	}
+
+	scan, err := scanMergedBlocksFile(source, scratch)
+	if err != nil {
+		return err
+	}
+
+	stats.compressed.Add(attrs.Size)
+	stats.uncompressed.Add(scan.dataSize)
+	stats.blocks.Add(scan.blockCount)
+
+	metadata := make(map[string]string, len(attrs.Metadata)+3)
 	maps.Copy(metadata, attrs.Metadata)
-	metadata[dataSizeMetadataKey] = strconv.FormatInt(dataSize, 10)
+	maps.Copy(metadata, firecore.MergedBlocksMetadata(scan.dataSize, scan.blockCount, scan.firstBlockTime))
 
 	conditions := storage.Conditions{GenerationMatch: attrs.Generation, MetagenerationMatch: attrs.Metageneration}
-	_, err := bucket.Object(attrs.Name).If(conditions).Update(ctx, storage.ObjectAttrsToUpdate{Metadata: metadata})
-	if err != nil {
+	if _, err := bucket.Object(attrs.Name).If(conditions).Update(ctx, storage.ObjectAttrsToUpdate{Metadata: metadata}); err != nil {
 		return fmt.Errorf("writing metadata: %w", err)
 	}
 	return nil
 }
 
-// uncompressedSize streams the object through the decoder and counts what comes out. The
-// decoded bytes go to io.Discard as they are produced, so a file of any size costs only the
-// decoder's window.
-func uncompressedSize(ctx context.Context, object *storage.ObjectHandle, decoder *zstd.Decoder) (int64, error) {
-	reader, err := object.NewReader(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("opening object: %w", err)
-	}
-	defer reader.Close()
-
-	return countDecompressed(decoder, reader)
+type mergedBlocksScan struct {
+	// dataSize is the number of bytes read off the decompressed stream.
+	dataSize       int64
+	blockCount     int64
+	firstBlockTime time.Time
 }
 
-// countDecompressed decodes everything the reader holds and returns how many bytes came out,
-// dropping them as they are produced.
-func countDecompressed(decoder *zstd.Decoder, reader io.Reader) (int64, error) {
-	if err := decoder.Reset(reader); err != nil {
-		return 0, fmt.Errorf("resetting decoder: %w", err)
-	}
-	// Release the reference to the reader once counted, the decoder outlives this file.
-	defer decoder.Reset(nil)
-
-	size, err := io.Copy(io.Discard, decoder)
+// scanMergedBlocksFile walks the whole dbin stream without ever holding a block: each one is
+// framed by its own length, so counting them costs the four length bytes and a read of the
+// block into a scratch buffer that is reused from block to block and from file to file. Of the
+// first block, only the head is looked at, far enough to reach its timestamp, which keeps a
+// large block out of memory just as much as a small one.
+func scanMergedBlocksFile(source io.Reader, scratch []byte) (mergedBlocksScan, error) {
+	// dbin.Reader buffers nothing, it pulls exactly the bytes it consumes, so the raw stream
+	// can be read on from where it stopped.
+	header, err := dbin.NewReader(source).ReadHeader()
 	if err != nil {
-		return 0, fmt.Errorf("decompressing: %w", err)
+		return mergedBlocksScan{}, fmt.Errorf("reading dbin header: %w", err)
 	}
-	return size, nil
+	scan := mergedBlocksScan{dataSize: int64(len(header.RawBytes))}
+
+	for {
+		length, err := readMessageLength(source)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				if scan.blockCount == 0 {
+					return mergedBlocksScan{}, errors.New("file holds no block")
+				}
+				return scan, nil
+			}
+			return mergedBlocksScan{}, fmt.Errorf("reading length of block %d: %w", scan.blockCount, err)
+		}
+
+		if scan.blockCount == 0 {
+			if scan.firstBlockTime, err = readBlockTimestamp(source, length, scratch); err != nil {
+				return mergedBlocksScan{}, err
+			}
+		} else if err := discard(source, length, scratch); err != nil {
+			return mergedBlocksScan{}, fmt.Errorf("reading block %d: %w", scan.blockCount, err)
+		}
+
+		scan.dataSize += messageFrameSize(length)
+		scan.blockCount++
+	}
 }
+
+// readMessageLength reads one dbin message's four big-endian length bytes, returning io.EOF and
+// nothing else when the stream ends cleanly on a message boundary.
+func readMessageLength(source io.Reader) (int64, error) {
+	var lengthBytes [4]byte
+	if _, err := io.ReadFull(source, lengthBytes[:]); err != nil {
+		return 0, err
+	}
+	return int64(binary.BigEndian.Uint32(lengthBytes[:])), nil
+}
+
+// readBlockTimestamp reads the head of the block, enough to reach its timestamp, then reads
+// past the rest of it. Only the block's metadata fields are decoded, the chain-specific payload
+// never being looked at, so this works on any chain without knowing the chain's block type.
+func readBlockTimestamp(source io.Reader, length int64, scratch []byte) (time.Time, error) {
+	head := int64(firecore.BlockTimestampPeekSize)
+	if head > length {
+		head = length
+	}
+	if _, err := io.ReadFull(source, scratch[:head]); err != nil {
+		return time.Time{}, fmt.Errorf("reading first block: %w", err)
+	}
+
+	timestamp, err := firecore.ExtractBlockTimestamp(scratch[:head])
+	if err != nil {
+		return time.Time{}, fmt.Errorf("reading first block timestamp: %w", err)
+	}
+
+	if err := discard(source, length-head, scratch); err != nil {
+		return time.Time{}, fmt.Errorf("reading first block: %w", err)
+	}
+	return timestamp, nil
+}
+
+// discard reads length bytes into the scratch buffer and drops them, so the stream advances
+// without any of it being kept and without any allocation.
+func discard(source io.Reader, length int64, scratch []byte) error {
+	for length > 0 {
+		chunk := int64(len(scratch))
+		if chunk > length {
+			chunk = length
+		}
+		read, err := io.ReadFull(source, scratch[:chunk])
+		length -= int64(read)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// messageFrameSize is what one dbin message takes on the stream: its four length bytes plus
+// the message itself.
+func messageFrameSize(messageSize int64) int64 { return 4 + messageSize }
 
 func startAnnotateProgress(ctx context.Context, stats *annotateStats, started time.Time, logger *zap.Logger) (stop func()) {
 	ticker := time.NewTicker(10 * time.Second)
@@ -353,7 +427,6 @@ func startAnnotateProgress(ctx context.Context, stats *annotateStats, started ti
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				elapsed := time.Since(started)
 				annotated := stats.annotated.Load()
 				logger.Info("annotating merged-blocks files",
 					zap.Int64("listed", stats.listed.Load()),
@@ -361,7 +434,7 @@ func startAnnotateProgress(ctx context.Context, stats *annotateStats, started ti
 					zap.Int64("skipped", stats.skipped.Load()),
 					zap.Int64("failed", stats.failed.Load()),
 					zap.String("uncompressed", humanize.Bytes(uint64(stats.uncompressed.Load()))),
-					zap.Float64("files_per_second", float64(annotated)/elapsed.Seconds()),
+					zap.Float64("files_per_second", float64(annotated)/time.Since(started).Seconds()),
 				)
 			}
 		}
@@ -372,77 +445,4 @@ func startAnnotateProgress(ctx context.Context, stats *annotateStats, started ti
 		close(quit)
 		<-done
 	}
-}
-
-func newGSClient(ctx context.Context, target gsTarget, cfg annotateConfig, logger *zap.Logger) (*storage.Client, error) {
-	if !cfg.useGRPC {
-		return storage.NewClient(ctx)
-	}
-
-	opts := []option.ClientOption{option.WithGRPCConnectionPool(grpcConnectionPool(cfg))}
-	if target.userProject != "" {
-		// DirectPath goes straight to the storage backend, which does not honour the
-		// x-goog-user-project gRPC metadata header requester-pays billing needs. Turning it
-		// off keeps gRPC while routing through the Google Front End, which does enforce it.
-		opts = append(opts, internaloption.EnableDirectPath(false))
-		logger.Warn("DirectPath disabled: it does not carry the requester-pays project, which this store url sets",
-			zap.String("project", target.userProject),
-		)
-	}
-	return storage.NewGRPCClient(ctx, opts...)
-}
-
-// grpcConnectionPool spreads the readers over several gRPC connections: a single HTTP/2
-// connection multiplexes every stream over one TCP socket, which caps throughput well before
-// a wide worker pool does.
-func grpcConnectionPool(cfg annotateConfig) int {
-	if cfg.connPool > 0 {
-		return cfg.connPool
-	}
-	pool := (cfg.parallelism + 31) / 32
-	if pool < 1 {
-		return 1
-	}
-	if pool > 16 {
-		return 16
-	}
-	return pool
-}
-
-// gsTarget is what the store URL says: where to look, plus the two query parameters dstore
-// reads off a 'gs://' URL, so the same URL means the same thing here as it does anywhere else
-// in the stack.
-type gsTarget struct {
-	bucket string
-	prefix string
-	// userProject bills reads to that project, for a requester-pays bucket ('?project=').
-	userProject string
-	// grpc is '?client_protocol=grpc', which selects the same transport as --grpc.
-	grpc bool
-}
-
-func parseGSURL(storeURL string) (gsTarget, error) {
-	parsed, err := url.Parse(storeURL)
-	if err != nil {
-		return gsTarget{}, fmt.Errorf("invalid store url %q: %w", storeURL, err)
-	}
-	if parsed.Scheme != "gs" {
-		return gsTarget{}, fmt.Errorf("store url %q must be a Google Cloud Storage url (gs://bucket/path), this tool writes object metadata which only that backend supports", storeURL)
-	}
-	if parsed.Host == "" {
-		return gsTarget{}, fmt.Errorf("store url %q has no bucket", storeURL)
-	}
-
-	prefix := strings.Trim(parsed.Path, "/")
-	if prefix != "" {
-		prefix += "/"
-	}
-
-	query := parsed.Query()
-	return gsTarget{
-		bucket:      parsed.Host,
-		prefix:      prefix,
-		userProject: query.Get("project"),
-		grpc:        query.Get("client_protocol") == "grpc",
-	}, nil
 }

--- a/cmd/tools/mergeblock/tools_annotate_merged_blocks_test.go
+++ b/cmd/tools/mergeblock/tools_annotate_merged_blocks_test.go
@@ -2,98 +2,161 @@ package mergeblock
 
 import (
 	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
 	"testing"
+	"time"
 
-	"github.com/klauspost/compress/zstd"
+	pbbstream "github.com/streamingfast/bstream/pb/sf/bstream/v1"
+	"github.com/streamingfast/dbin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func TestParseGSURL(t *testing.T) {
+// writeMergedBlocksFile builds a dbin stream of blocks whose payloads are payloadSize bytes
+// each, one second apart starting at firstBlockTime.
+func writeMergedBlocksFile(t *testing.T, blockCount int, payloadSize int, firstBlockTime time.Time) []byte {
+	t.Helper()
+
+	var out bytes.Buffer
+	writer := dbin.NewWriter(&out)
+	require.NoError(t, writer.WriteHeader("type.googleapis.com/sf.test.type.v1.Block"))
+
+	for i := range blockCount {
+		block := &pbbstream.Block{
+			Number:    uint64(100 + i),
+			Id:        "00000000000000000000000000000000000000000000000000000000000000ff",
+			ParentId:  "00000000000000000000000000000000000000000000000000000000000000fe",
+			ParentNum: uint64(99 + i),
+			Timestamp: timestamppb.New(firstBlockTime.Add(time.Duration(i) * time.Second)),
+			Payload:   &anypb.Any{TypeUrl: "type.googleapis.com/sf.test.type.v1.Block", Value: bytes.Repeat([]byte("p"), payloadSize)},
+		}
+		message, err := proto.Marshal(block)
+		require.NoError(t, err)
+		require.NoError(t, writer.WriteMessage(message))
+	}
+
+	return out.Bytes()
+}
+
+func TestScanMergedBlocksFile(t *testing.T) {
+	firstBlockTime := time.Date(2025, 10, 12, 10, 23, 12, 0, time.UTC)
+
 	tests := []struct {
-		name      string
-		url       string
-		expect    gsTarget
-		expectErr string
+		name        string
+		blockCount  int
+		payloadSize int
 	}{
-		{name: "bucket and folder", url: "gs://example-bucket/eth-mainnet/merged", expect: gsTarget{bucket: "example-bucket", prefix: "eth-mainnet/merged/"}},
-		{name: "trailing slash", url: "gs://example-bucket/eth-mainnet/merged/", expect: gsTarget{bucket: "example-bucket", prefix: "eth-mainnet/merged/"}},
-		{name: "bucket root", url: "gs://example-bucket", expect: gsTarget{bucket: "example-bucket"}},
-		{name: "requester pays project", url: "gs://example-bucket/merged?project=my-project", expect: gsTarget{bucket: "example-bucket", prefix: "merged/", userProject: "my-project"}},
-		{name: "grpc client protocol", url: "gs://example-bucket/merged?client_protocol=grpc", expect: gsTarget{bucket: "example-bucket", prefix: "merged/", grpc: true}},
-		{name: "http client protocol", url: "gs://example-bucket/merged?client_protocol=http", expect: gsTarget{bucket: "example-bucket", prefix: "merged/"}},
-		{name: "both parameters", url: "gs://example-bucket/merged?project=my-project&client_protocol=grpc", expect: gsTarget{bucket: "example-bucket", prefix: "merged/", userProject: "my-project", grpc: true}},
-		{name: "local path refused", url: "/data/merged", expectErr: "must be a Google Cloud Storage url"},
-		{name: "s3 refused", url: "s3://example-bucket/merged", expectErr: "must be a Google Cloud Storage url"},
-		{name: "no bucket", url: "gs:///merged", expectErr: "has no bucket"},
+		{name: "single small block", blockCount: 1, payloadSize: 16},
+		{name: "many small blocks", blockCount: 100, payloadSize: 128},
+		// Blocks far larger than the scratch buffer must still be walked without being held.
+		{name: "blocks larger than the scratch buffer", blockCount: 3, payloadSize: 3 * scanScratchBufferSize},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			target, err := parseGSURL(test.url)
-			if test.expectErr != "" {
-				require.ErrorContains(t, err, test.expectErr)
-				return
-			}
+			file := writeMergedBlocksFile(t, test.blockCount, test.payloadSize, firstBlockTime)
+
+			scratch := make([]byte, scanScratchBufferSize)
+			scan, err := scanMergedBlocksFile(bytes.NewReader(file), scratch)
 			require.NoError(t, err)
-			assert.Equal(t, test.expect, target)
+
+			assert.Equal(t, int64(len(file)), scan.dataSize)
+			assert.Equal(t, int64(test.blockCount), scan.blockCount)
+			assert.Equal(t, firstBlockTime, scan.firstBlockTime)
 		})
 	}
 }
 
-func TestMergedBlocksFileRegex(t *testing.T) {
-	tests := []struct {
-		base      string
-		matches   bool
-		zstSuffix string
-	}{
-		{base: "0000012300.dbin.zst", matches: true, zstSuffix: ".zst"},
-		{base: "0000012300.dbin", matches: true, zstSuffix: ""},
-		{base: "0000012300.dbin.gz", matches: false},
-		{base: "123.dbin.zst", matches: false},
-		{base: "0000012300-0000012400.output.zst", matches: false},
-		{base: "substreams.spkg.zst", matches: false},
-	}
+// The scratch buffer is reused across files, so a scan must not depend on what the last one
+// left in it.
+func TestScanMergedBlocksFileReusesScratch(t *testing.T) {
+	scratch := make([]byte, scanScratchBufferSize)
 
-	for _, test := range tests {
-		t.Run(test.base, func(t *testing.T) {
-			match := mergedBlocksFileRE.FindStringSubmatch(test.base)
-			if !test.matches {
-				assert.Nil(t, match)
-				return
+	for i, blockTime := range []time.Time{
+		time.Date(2025, 10, 12, 10, 23, 12, 0, time.UTC),
+		time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC),
+	} {
+		file := writeMergedBlocksFile(t, 5+i, 64, blockTime)
+
+		scan, err := scanMergedBlocksFile(bytes.NewReader(file), scratch)
+		require.NoError(t, err)
+		assert.Equal(t, int64(len(file)), scan.dataSize)
+		assert.Equal(t, int64(5+i), scan.blockCount)
+		assert.Equal(t, blockTime, scan.firstBlockTime)
+	}
+}
+
+func TestScanMergedBlocksFileErrors(t *testing.T) {
+	scratch := make([]byte, scanScratchBufferSize)
+	firstBlockTime := time.Date(2025, 10, 12, 10, 23, 12, 0, time.UTC)
+
+	t.Run("not a dbin file", func(t *testing.T) {
+		_, err := scanMergedBlocksFile(bytes.NewReader([]byte("not a dbin file at all")), scratch)
+		require.ErrorContains(t, err, "reading dbin header")
+	})
+
+	t.Run("header without a block", func(t *testing.T) {
+		var out bytes.Buffer
+		writer := dbin.NewWriter(&out)
+		require.NoError(t, writer.WriteHeader("type.googleapis.com/sf.test.type.v1.Block"))
+
+		_, err := scanMergedBlocksFile(bytes.NewReader(out.Bytes()), scratch)
+		require.ErrorContains(t, err, "file holds no block")
+	})
+
+	t.Run("truncated block", func(t *testing.T) {
+		file := writeMergedBlocksFile(t, 4, 1024, firstBlockTime)
+
+		_, err := scanMergedBlocksFile(bytes.NewReader(file[:len(file)-512]), scratch)
+		require.ErrorContains(t, err, "reading block")
+	})
+
+	t.Run("length announcing more than is there", func(t *testing.T) {
+		file := writeMergedBlocksFile(t, 1, 64, firstBlockTime)
+		// Overstate the length of a second message that is not there at all.
+		file = binary.BigEndian.AppendUint32(file, 4096)
+
+		_, err := scanMergedBlocksFile(bytes.NewReader(file), scratch)
+		require.ErrorContains(t, err, "reading block 1")
+	})
+}
+
+func TestIsAnnotated(t *testing.T) {
+	complete := map[string]string{
+		dataSizeMetadataKey:  "1024",
+		itemCountMetadataKey: "100",
+		timestampMetadataKey: "2025-10-12 10:23:12",
+	}
+	assert.True(t, isAnnotated(complete))
+
+	for _, missing := range []string{dataSizeMetadataKey, itemCountMetadataKey, timestampMetadataKey} {
+		partial := map[string]string{}
+		for key, value := range complete {
+			if key != missing {
+				partial[key] = value
 			}
-			require.NotNil(t, match)
-			assert.Equal(t, test.zstSuffix, match[2])
-		})
+		}
+		assert.False(t, isAnnotated(partial), "should not be annotated without %q", missing)
 	}
+
+	assert.False(t, isAnnotated(nil))
 }
 
-func TestCountDecompressed(t *testing.T) {
-	decoder, err := zstd.NewReader(nil, zstd.WithDecoderConcurrency(1), zstd.WithDecoderLowmem(true))
-	require.NoError(t, err)
-	defer decoder.Close()
+func TestDiscard(t *testing.T) {
+	scratch := make([]byte, 8)
+	source := bytes.NewReader(bytes.Repeat([]byte("x"), 100))
 
-	// Reusing one decoder across files is what the workers do, so count twice.
-	for _, payloadSize := range []int{0, 1024, 5 * 1024 * 1024} {
-		payload := bytes.Repeat([]byte("firehose merged blocks payload "), payloadSize/31+1)[:payloadSize]
+	require.NoError(t, discard(source, 60, scratch))
+	assert.Equal(t, 40, source.Len())
 
-		var compressed bytes.Buffer
-		encoder, err := zstd.NewWriter(&compressed)
-		require.NoError(t, err)
-		_, err = encoder.Write(payload)
-		require.NoError(t, err)
-		require.NoError(t, encoder.Close())
-
-		size, err := countDecompressed(decoder, bytes.NewReader(compressed.Bytes()))
-		require.NoError(t, err)
-		assert.Equal(t, int64(payloadSize), size)
-	}
-}
-
-func TestGRPCConnectionPool(t *testing.T) {
-	assert.Equal(t, 7, grpcConnectionPool(annotateConfig{parallelism: 32, connPool: 7}))
-	assert.Equal(t, 1, grpcConnectionPool(annotateConfig{parallelism: 1}))
-	assert.Equal(t, 1, grpcConnectionPool(annotateConfig{parallelism: 32}))
-	assert.Equal(t, 2, grpcConnectionPool(annotateConfig{parallelism: 33}))
-	assert.Equal(t, 16, grpcConnectionPool(annotateConfig{parallelism: 4096}))
+	// Asking for more than remains reports the short stream rather than succeeding, whether the
+	// stream runs out on a chunk boundary (io.EOF) or inside one (io.ErrUnexpectedEOF).
+	err := discard(source, 60, scratch)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF), "got %v", err)
 }

--- a/cmd/tools/mergeblock/tools_annotate_merged_blocks_test.go
+++ b/cmd/tools/mergeblock/tools_annotate_merged_blocks_test.go
@@ -1,0 +1,99 @@
+package mergeblock
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGSURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		expect    gsTarget
+		expectErr string
+	}{
+		{name: "bucket and folder", url: "gs://example-bucket/eth-mainnet/merged", expect: gsTarget{bucket: "example-bucket", prefix: "eth-mainnet/merged/"}},
+		{name: "trailing slash", url: "gs://example-bucket/eth-mainnet/merged/", expect: gsTarget{bucket: "example-bucket", prefix: "eth-mainnet/merged/"}},
+		{name: "bucket root", url: "gs://example-bucket", expect: gsTarget{bucket: "example-bucket"}},
+		{name: "requester pays project", url: "gs://example-bucket/merged?project=my-project", expect: gsTarget{bucket: "example-bucket", prefix: "merged/", userProject: "my-project"}},
+		{name: "grpc client protocol", url: "gs://example-bucket/merged?client_protocol=grpc", expect: gsTarget{bucket: "example-bucket", prefix: "merged/", grpc: true}},
+		{name: "http client protocol", url: "gs://example-bucket/merged?client_protocol=http", expect: gsTarget{bucket: "example-bucket", prefix: "merged/"}},
+		{name: "both parameters", url: "gs://example-bucket/merged?project=my-project&client_protocol=grpc", expect: gsTarget{bucket: "example-bucket", prefix: "merged/", userProject: "my-project", grpc: true}},
+		{name: "local path refused", url: "/data/merged", expectErr: "must be a Google Cloud Storage url"},
+		{name: "s3 refused", url: "s3://example-bucket/merged", expectErr: "must be a Google Cloud Storage url"},
+		{name: "no bucket", url: "gs:///merged", expectErr: "has no bucket"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			target, err := parseGSURL(test.url)
+			if test.expectErr != "" {
+				require.ErrorContains(t, err, test.expectErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.expect, target)
+		})
+	}
+}
+
+func TestMergedBlocksFileRegex(t *testing.T) {
+	tests := []struct {
+		base      string
+		matches   bool
+		zstSuffix string
+	}{
+		{base: "0000012300.dbin.zst", matches: true, zstSuffix: ".zst"},
+		{base: "0000012300.dbin", matches: true, zstSuffix: ""},
+		{base: "0000012300.dbin.gz", matches: false},
+		{base: "123.dbin.zst", matches: false},
+		{base: "0000012300-0000012400.output.zst", matches: false},
+		{base: "substreams.spkg.zst", matches: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.base, func(t *testing.T) {
+			match := mergedBlocksFileRE.FindStringSubmatch(test.base)
+			if !test.matches {
+				assert.Nil(t, match)
+				return
+			}
+			require.NotNil(t, match)
+			assert.Equal(t, test.zstSuffix, match[2])
+		})
+	}
+}
+
+func TestCountDecompressed(t *testing.T) {
+	decoder, err := zstd.NewReader(nil, zstd.WithDecoderConcurrency(1), zstd.WithDecoderLowmem(true))
+	require.NoError(t, err)
+	defer decoder.Close()
+
+	// Reusing one decoder across files is what the workers do, so count twice.
+	for _, payloadSize := range []int{0, 1024, 5 * 1024 * 1024} {
+		payload := bytes.Repeat([]byte("firehose merged blocks payload "), payloadSize/31+1)[:payloadSize]
+
+		var compressed bytes.Buffer
+		encoder, err := zstd.NewWriter(&compressed)
+		require.NoError(t, err)
+		_, err = encoder.Write(payload)
+		require.NoError(t, err)
+		require.NoError(t, encoder.Close())
+
+		size, err := countDecompressed(decoder, bytes.NewReader(compressed.Bytes()))
+		require.NoError(t, err)
+		assert.Equal(t, int64(payloadSize), size)
+	}
+}
+
+func TestGRPCConnectionPool(t *testing.T) {
+	assert.Equal(t, 7, grpcConnectionPool(annotateConfig{parallelism: 32, connPool: 7}))
+	assert.Equal(t, 1, grpcConnectionPool(annotateConfig{parallelism: 1}))
+	assert.Equal(t, 1, grpcConnectionPool(annotateConfig{parallelism: 32}))
+	assert.Equal(t, 2, grpcConnectionPool(annotateConfig{parallelism: 33}))
+	assert.Equal(t, 16, grpcConnectionPool(annotateConfig{parallelism: 4096}))
+}

--- a/cmd/tools/mergeblock/tools_stats_merged_blocks.go
+++ b/cmd/tools/mergeblock/tools_stats_merged_blocks.go
@@ -1,0 +1,256 @@
+package mergeblock
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"text/tabwriter"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/spf13/cobra"
+	"github.com/streamingfast/cli"
+	"github.com/streamingfast/cli/sflags"
+	"github.com/streamingfast/firehose-core/cmd/tools/stylex"
+	"go.uber.org/zap"
+)
+
+func NewToolsStatsMergedBlocksCmd(rootLog *zap.Logger) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stats-merged-blocks <gs-store-url>",
+		Short: "Report size, block count and compression of a merged-blocks store, month by month",
+		Long: cli.Dedent(`
+			Reports on a range of a merged-blocks store: total compressed and uncompressed
+			size, block count, compression ratio and bytes per block, broken down by month
+			and totalled over the range.
+
+			Nothing is downloaded. Every number comes from the 'datasize', 'itemcount' and
+			'timestamp' metadata entries that 'firecore tools annotate-merged-blocks' wrote
+			on each object, and those come back with the listing, so the whole report costs
+			one listing however large the range is. Run the annotation first: files missing
+			any of the three entries are counted and reported, and contribute to nothing.
+
+			The month a file counts towards is the month of its first block, so a file
+			straddling a month boundary counts entirely towards the month it starts in.
+
+			This only works on Google Cloud Storage ('gs://'), where the annotation lives.
+		`),
+		Example: cli.Dedent(`
+			# Whole store
+			firecore tools stats-merged-blocks gs://example-bucket/eth-mainnet/merged
+
+			# One range
+			firecore tools stats-merged-blocks gs://example-bucket/eth-mainnet/merged \
+			  --start-block 15000000 --stop-block 16000000
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg := statsConfig{
+				useGRPC:    sflags.MustGetBool(cmd, "grpc"),
+				startBlock: sflags.MustGetUint64(cmd, "start-block"),
+				stopBlock:  sflags.MustGetUint64(cmd, "stop-block"),
+			}
+			cmd.SilenceUsage = true
+			return runStatsMergedBlocks(cmd.Context(), args[0], cfg, rootLog)
+		},
+	}
+
+	cmd.Flags().Bool("grpc", false, "Talk to Cloud Storage over its gRPC API instead of JSON/XML over HTTP")
+	cmd.Flags().Uint64("start-block", 0, "Only count files whose first block is at or above this block")
+	cmd.Flags().Uint64("stop-block", 0, "Only count files whose first block is below this block, 0 for no upper bound")
+
+	return cmd
+}
+
+type statsConfig struct {
+	useGRPC    bool
+	startBlock uint64
+	stopBlock  uint64
+}
+
+// mergedBlocksTally accumulates one bucket of the report, a month or the whole range.
+type mergedBlocksTally struct {
+	files        int64
+	blocks       int64
+	compressed   int64
+	uncompressed int64
+}
+
+func (t *mergedBlocksTally) add(other mergedBlocksTally) {
+	t.files += other.files
+	t.blocks += other.blocks
+	t.compressed += other.compressed
+	t.uncompressed += other.uncompressed
+}
+
+// compressionRatio is how many uncompressed bytes each stored byte stands for.
+func (t mergedBlocksTally) compressionRatio() float64 {
+	if t.compressed == 0 {
+		return 0
+	}
+	return float64(t.uncompressed) / float64(t.compressed)
+}
+
+func (t mergedBlocksTally) uncompressedPerBlock() float64 {
+	if t.blocks == 0 {
+		return 0
+	}
+	return float64(t.uncompressed) / float64(t.blocks)
+}
+
+func (t mergedBlocksTally) compressedPerBlock() float64 {
+	if t.blocks == 0 {
+		return 0
+	}
+	return float64(t.compressed) / float64(t.blocks)
+}
+
+func runStatsMergedBlocks(ctx context.Context, storeURL string, cfg statsConfig, logger *zap.Logger) error {
+	target, err := parseGSURL(storeURL)
+	if err != nil {
+		return err
+	}
+	cfg.useGRPC = cfg.useGRPC || target.grpc
+
+	if cfg.stopBlock != 0 && cfg.stopBlock <= cfg.startBlock {
+		return fmt.Errorf("--stop-block %d must be above --start-block %d", cfg.stopBlock, cfg.startBlock)
+	}
+
+	client, err := newGSClient(ctx, target, cfg.useGRPC, 1, logger)
+	if err != nil {
+		return fmt.Errorf("creating storage client: %w", err)
+	}
+	defer client.Close()
+
+	fmt.Println(stylex.Title("Merged Blocks Statistics"))
+	fmt.Println(stylex.Dim(stylex.Separator(80)))
+	fmt.Println(stylex.Labelf("Store: %s", storeURL))
+	fmt.Println(stylex.Labelf("Range: %s", describeBlockRange(cfg.startBlock, cfg.stopBlock)))
+	fmt.Println()
+
+	months := map[string]*mergedBlocksTally{}
+	var total mergedBlocksTally
+	var unannotated, firstBlock, lastBlock uint64
+	started := time.Now()
+
+	err = walkMergedBlocks(ctx, bucketHandle(client, target), target.prefix, cfg.startBlock, cfg.stopBlock,
+		[]string{"Name", "Size", "Metadata"},
+		func(object mergedBlocksObject) error {
+			if total.files == 0 {
+				firstBlock = object.lowBlockNum
+			}
+			lastBlock = object.lowBlockNum
+
+			file, ok := readAnnotation(object)
+			if !ok {
+				unannotated++
+				logger.Debug("file carries no complete annotation", zap.String("file", object.attrs.Name))
+				return nil
+			}
+
+			month := months[file.month]
+			if month == nil {
+				month = &mergedBlocksTally{}
+				months[file.month] = month
+			}
+			month.add(file.tally)
+			total.add(file.tally)
+			return nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("listing %s: %w", storeURL, err)
+	}
+
+	if total.files == 0 && unannotated == 0 {
+		fmt.Println(stylex.Note("No merged-blocks file found in that range"))
+		return nil
+	}
+
+	printMergedBlocksTable(months, total)
+
+	fmt.Println()
+	fmt.Println(stylex.Valuef("Blocks seen: %s to %s", humanize.Comma(int64(firstBlock)), humanize.Comma(int64(lastBlock))))
+	fmt.Println(stylex.Valuef("Listed in:   %s", time.Since(started).Round(time.Millisecond)))
+	if unannotated > 0 {
+		fmt.Println(stylex.Warnf("%d file(s) carry no complete annotation and count towards nothing, run 'firecore tools annotate-merged-blocks' on them", unannotated))
+	}
+	return nil
+}
+
+// annotatedFile is one merged-blocks file's contribution to the report.
+type annotatedFile struct {
+	month string
+	tally mergedBlocksTally
+}
+
+// readAnnotation reads back what annotate-merged-blocks wrote. A file missing any of the three
+// entries counts towards nothing: a partial annotation would silently understate every total.
+func readAnnotation(object mergedBlocksObject) (annotatedFile, bool) {
+	dataSize, err := strconv.ParseInt(object.attrs.Metadata[dataSizeMetadataKey], 10, 64)
+	if err != nil {
+		return annotatedFile{}, false
+	}
+	blocks, err := strconv.ParseInt(object.attrs.Metadata[itemCountMetadataKey], 10, 64)
+	if err != nil {
+		return annotatedFile{}, false
+	}
+	timestamp, err := time.Parse(timestampMetadataLayout, object.attrs.Metadata[timestampMetadataKey])
+	if err != nil {
+		return annotatedFile{}, false
+	}
+
+	return annotatedFile{
+		month: timestamp.Format("2006-01"),
+		tally: mergedBlocksTally{
+			files:        1,
+			blocks:       blocks,
+			compressed:   object.attrs.Size,
+			uncompressed: dataSize,
+		},
+	}, true
+}
+
+func printMergedBlocksTable(months map[string]*mergedBlocksTally, total mergedBlocksTally) {
+	names := make([]string, 0, len(months))
+	for name := range months {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	table := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', tabwriter.AlignRight)
+	fmt.Fprintln(table, "MONTH\tFILES\tBLOCKS\tCOMPRESSED\tUNCOMPRESSED\tRATIO\tCOMP./BLOCK\tUNCOMP./BLOCK\t")
+	for _, name := range names {
+		printMergedBlocksRow(table, name, *months[name])
+	}
+	if len(names) > 1 {
+		fmt.Fprintln(table, "\t\t\t\t\t\t\t\t")
+		printMergedBlocksRow(table, "TOTAL", total)
+	}
+	table.Flush()
+}
+
+func printMergedBlocksRow(table *tabwriter.Writer, name string, tally mergedBlocksTally) {
+	fmt.Fprintf(table, "%s\t%s\t%s\t%s\t%s\t%.2fx\t%s\t%s\t\n",
+		name,
+		humanize.Comma(tally.files),
+		humanize.Comma(tally.blocks),
+		humanize.Bytes(uint64(tally.compressed)),
+		humanize.Bytes(uint64(tally.uncompressed)),
+		tally.compressionRatio(),
+		humanize.Bytes(uint64(tally.compressedPerBlock())),
+		humanize.Bytes(uint64(tally.uncompressedPerBlock())),
+	)
+}
+
+func describeBlockRange(startBlock, stopBlock uint64) string {
+	if startBlock == 0 && stopBlock == 0 {
+		return "whole store"
+	}
+	if stopBlock == 0 {
+		return fmt.Sprintf("%s and up", humanize.Comma(int64(startBlock)))
+	}
+	return fmt.Sprintf("%s to %s (exclusive)", humanize.Comma(int64(startBlock)), humanize.Comma(int64(stopBlock)))
+}

--- a/cmd/tools/mergeblock/tools_stats_merged_blocks_test.go
+++ b/cmd/tools/mergeblock/tools_stats_merged_blocks_test.go
@@ -1,0 +1,81 @@
+package mergeblock
+
+import (
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadAnnotation(t *testing.T) {
+	tests := []struct {
+		name     string
+		size     int64
+		metadata map[string]string
+		expect   annotatedFile
+		expectOK bool
+	}{
+		{
+			name:     "complete",
+			size:     1000,
+			metadata: map[string]string{dataSizeMetadataKey: "4096", itemCountMetadataKey: "100", timestampMetadataKey: "2025-10-12 10:23:12"},
+			expect: annotatedFile{
+				month: "2025-10",
+				tally: mergedBlocksTally{files: 1, blocks: 100, compressed: 1000, uncompressed: 4096},
+			},
+			expectOK: true,
+		},
+		{name: "no metadata at all", size: 1000},
+		{
+			name:     "missing item count",
+			size:     1000,
+			metadata: map[string]string{dataSizeMetadataKey: "4096", timestampMetadataKey: "2025-10-12 10:23:12"},
+		},
+		{
+			name:     "timestamp in another format",
+			size:     1000,
+			metadata: map[string]string{dataSizeMetadataKey: "4096", itemCountMetadataKey: "100", timestampMetadataKey: "2025-10-12T10:23:12Z"},
+		},
+		{
+			name:     "data size is not a number",
+			size:     1000,
+			metadata: map[string]string{dataSizeMetadataKey: "4 KiB", itemCountMetadataKey: "100", timestampMetadataKey: "2025-10-12 10:23:12"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			object := mergedBlocksObject{attrs: &storage.ObjectAttrs{Size: test.size, Metadata: test.metadata}}
+
+			file, ok := readAnnotation(object)
+			require.Equal(t, test.expectOK, ok)
+			if test.expectOK {
+				assert.Equal(t, test.expect, file)
+			}
+		})
+	}
+}
+
+func TestMergedBlocksTally(t *testing.T) {
+	var tally mergedBlocksTally
+	tally.add(mergedBlocksTally{files: 1, blocks: 100, compressed: 1000, uncompressed: 4000})
+	tally.add(mergedBlocksTally{files: 1, blocks: 100, compressed: 1000, uncompressed: 2000})
+
+	assert.Equal(t, mergedBlocksTally{files: 2, blocks: 200, compressed: 2000, uncompressed: 6000}, tally)
+	assert.Equal(t, 3.0, tally.compressionRatio())
+	assert.Equal(t, 30.0, tally.uncompressedPerBlock())
+	assert.Equal(t, 10.0, tally.compressedPerBlock())
+
+	// An empty tally divides by nothing.
+	var empty mergedBlocksTally
+	assert.Equal(t, 0.0, empty.compressionRatio())
+	assert.Equal(t, 0.0, empty.uncompressedPerBlock())
+	assert.Equal(t, 0.0, empty.compressedPerBlock())
+}
+
+func TestDescribeBlockRange(t *testing.T) {
+	assert.Equal(t, "whole store", describeBlockRange(0, 0))
+	assert.Equal(t, "1,000,000 and up", describeBlockRange(1000000, 0))
+	assert.Equal(t, "1,000,000 to 2,000,000 (exclusive)", describeBlockRange(1000000, 2000000))
+}

--- a/cmd/tools/tools.go
+++ b/cmd/tools/tools.go
@@ -83,6 +83,7 @@ func ConfigureToolsCmd[B firecore.Block](
 	ToolsCmd.AddCommand(mergeblock.NewToolsUnmergeBlocksCmd(chain, logger))
 	ToolsCmd.AddCommand(mergeblock.NewToolsMergeBlocksCmd(chain, logger))
 	ToolsCmd.AddCommand(mergeblock.NewToolsResizeMergedBlocksCmd(chain, logger))
+	ToolsCmd.AddCommand(mergeblock.NewToolsAnnotateMergedBlocksCmd(logger))
 	ToolsCmd.AddCommand(fix.NewToolsFixBloatedMergedBlocks(chain, logger))
 	ToolsCmd.AddCommand(relayer.NewToolsRelayerGroup(chain, logger))
 	ToolsCmd.AddCommand(substreams.NewToolsSubstreamsCmd(chain, logger))

--- a/cmd/tools/tools.go
+++ b/cmd/tools/tools.go
@@ -84,6 +84,7 @@ func ConfigureToolsCmd[B firecore.Block](
 	ToolsCmd.AddCommand(mergeblock.NewToolsMergeBlocksCmd(chain, logger))
 	ToolsCmd.AddCommand(mergeblock.NewToolsResizeMergedBlocksCmd(chain, logger))
 	ToolsCmd.AddCommand(mergeblock.NewToolsAnnotateMergedBlocksCmd(logger))
+	ToolsCmd.AddCommand(mergeblock.NewToolsStatsMergedBlocksCmd(logger))
 	ToolsCmd.AddCommand(fix.NewToolsFixBloatedMergedBlocks(chain, logger))
 	ToolsCmd.AddCommand(relayer.NewToolsRelayerGroup(chain, logger))
 	ToolsCmd.AddCommand(substreams.NewToolsSubstreamsCmd(chain, logger))

--- a/merged_blocks_metadata.go
+++ b/merged_blocks_metadata.go
@@ -1,0 +1,45 @@
+package firecore
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/streamingfast/dstore"
+)
+
+// The custom object metadata carried by each merged-blocks file. The merger writes all three
+// as it uploads a bundle, `firecore tools annotate-merged-blocks` backfills them on files
+// written before that, and `firecore tools stats-merged-blocks` reports from them without
+// downloading anything.
+const (
+	// MergedBlocksDataSizeMetadataKey holds the decimal number of bytes the file holds once
+	// decompressed.
+	MergedBlocksDataSizeMetadataKey = "datasize"
+
+	// MergedBlocksItemCountMetadataKey holds the decimal number of blocks the file holds.
+	MergedBlocksItemCountMetadataKey = "itemcount"
+
+	// MergedBlocksTimestampMetadataKey holds the time of the file's first block, formatted as
+	// MergedBlocksTimestampLayout in UTC.
+	MergedBlocksTimestampMetadataKey = "timestamp"
+
+	MergedBlocksTimestampLayout = "2006-01-02 15:04:05"
+)
+
+// MergedBlocksMetadata describes one merged-blocks file. The three entries are always written
+// together: a reader that finds only some of them cannot tell whether they describe the same
+// version of the file, so it must treat the file as unannotated.
+func MergedBlocksMetadata(dataSize, blockCount int64, firstBlockTime time.Time) map[string]string {
+	return map[string]string{
+		MergedBlocksDataSizeMetadataKey:  strconv.FormatInt(dataSize, 10),
+		MergedBlocksItemCountMetadataKey: strconv.FormatInt(blockCount, 10),
+		MergedBlocksTimestampMetadataKey: firstBlockTime.UTC().Format(MergedBlocksTimestampLayout),
+	}
+}
+
+// MergedBlocksMetadataSupported reports whether the store keeps custom metadata on an object
+// that can be read back from a listing, which is what makes the annotation worth writing.
+// Google Cloud Storage is the only backend this is used with.
+func MergedBlocksMetadataSupported(store dstore.Store) bool {
+	return store.BaseURL().Scheme == "gs"
+}

--- a/merger/block_time.go
+++ b/merger/block_time.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	"github.com/streamingfast/bstream"
-	"google.golang.org/protobuf/encoding/protowire"
+	firecore "github.com/streamingfast/firehose-core"
 )
 
 // readBlockTimestamp opens a one-block-file and extracts the block timestamp
-// by reading at most 512 bytes past the DBIN header.
+// by reading only as far as the timestamp field of its first block.
 func readBlockTimestamp(ctx context.Context, obf *bstream.OneBlockFile, opener func(context.Context, *bstream.OneBlockFile) (io.ReadCloser, error)) (time.Time, error) {
 	r, err := opener(ctx, obf)
 	if err != nil {
@@ -36,80 +36,14 @@ func readBlockTimestamp(ctx context.Context, obf *bstream.OneBlockFile, opener f
 	}
 	msgLen := int(binary.BigEndian.Uint32(lengthBuf[:]))
 
-	// Read only enough bytes to reach field 4 (timestamp). Fields 1-3 are
-	// number (varint ~2B), id (string ~34B) and parent_id (string ~34B), so
-	// 512 bytes is more than enough to reach the timestamp before field 11 (payload).
 	limit := msgLen
-	if limit > 512 {
-		limit = 512
+	if limit > firecore.BlockTimestampPeekSize {
+		limit = firecore.BlockTimestampPeekSize
 	}
 	buf := make([]byte, limit)
 	if _, err := io.ReadFull(r, buf); err != nil {
 		return time.Time{}, fmt.Errorf("reading block message bytes: %w", err)
 	}
 
-	return extractTimestampFromProto(buf)
-}
-
-// extractTimestampFromProto scans a partial pbbstream.Block protobuf payload
-// field by field, returning as soon as field 4 (google.protobuf.Timestamp) is found.
-func extractTimestampFromProto(data []byte) (time.Time, error) {
-	for len(data) > 0 {
-		num, typ, n := protowire.ConsumeTag(data)
-		if n < 0 {
-			return time.Time{}, protowire.ParseError(n)
-		}
-		data = data[n:]
-
-		if num == 4 && typ == protowire.BytesType { // field 4 = timestamp (embedded message)
-			tsBytes, n := protowire.ConsumeBytes(data)
-			if n < 0 {
-				return time.Time{}, protowire.ParseError(n)
-			}
-			return decodeProtoTimestamp(tsBytes)
-		}
-
-		n = protowire.ConsumeFieldValue(num, typ, data)
-		if n < 0 {
-			return time.Time{}, protowire.ParseError(n)
-		}
-		data = data[n:]
-	}
-	return time.Time{}, fmt.Errorf("timestamp field not found in first 512 bytes of block")
-}
-
-// decodeProtoTimestamp decodes a serialized google.protobuf.Timestamp (seconds=1, nanos=2).
-func decodeProtoTimestamp(data []byte) (time.Time, error) {
-	var seconds int64
-	var nanos int32
-	for len(data) > 0 {
-		num, typ, n := protowire.ConsumeTag(data)
-		if n < 0 {
-			return time.Time{}, protowire.ParseError(n)
-		}
-		data = data[n:]
-		switch {
-		case num == 1 && typ == protowire.VarintType:
-			v, n := protowire.ConsumeVarint(data)
-			if n < 0 {
-				return time.Time{}, protowire.ParseError(n)
-			}
-			seconds = int64(v)
-			data = data[n:]
-		case num == 2 && typ == protowire.VarintType:
-			v, n := protowire.ConsumeVarint(data)
-			if n < 0 {
-				return time.Time{}, protowire.ParseError(n)
-			}
-			nanos = int32(v)
-			data = data[n:]
-		default:
-			n = protowire.ConsumeFieldValue(num, typ, data)
-			if n < 0 {
-				return time.Time{}, protowire.ParseError(n)
-			}
-			data = data[n:]
-		}
-	}
-	return time.Unix(seconds, int64(nanos)).UTC(), nil
+	return firecore.ExtractBlockTimestamp(buf)
 }

--- a/merger/merged_blocks_annotation_test.go
+++ b/merger/merged_blocks_annotation_test.go
@@ -1,0 +1,140 @@
+package merger
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/streamingfast/bstream"
+	pbbstream "github.com/streamingfast/bstream/pb/sf/bstream/v1"
+	"github.com/streamingfast/dstore"
+	firecore "github.com/streamingfast/firehose-core"
+	"github.com/streamingfast/firehose-core/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// gsMockStore is a mock store that presents itself as Google Cloud Storage, the only backend
+// the merger annotates merged-blocks files on.
+type gsMockStore struct {
+	*dstore.MockStore
+}
+
+func (s *gsMockStore) BaseURL() *url.URL {
+	return &url.URL{Scheme: "gs", Host: "example-bucket", Path: "/merged"}
+}
+
+func newGSMockStore(writeFunc func(base string, f io.Reader) error) *gsMockStore {
+	return &gsMockStore{MockStore: dstore.NewMockStore(writeFunc)}
+}
+
+// timedBlockReader returns a one-block file holding a block of the given number and time, with a
+// payload far larger than the head the timestamp is read from.
+func timedBlockReader(t *testing.T, number uint64, blockTime time.Time) io.ReadCloser {
+	t.Helper()
+
+	out := new(bytes.Buffer)
+	writer, err := bstream.NewDBinBlockWriter(out)
+	require.NoError(t, err)
+
+	payload, err := anypb.New(&test.Block{Number: number})
+	require.NoError(t, err)
+	payload.Value = bytes.Repeat([]byte("p"), 4096)
+
+	require.NoError(t, writer.Write(&pbbstream.Block{
+		Number:    number,
+		Id:        "00000000000000000000000000000000000000000000000000000000000000ff",
+		ParentId:  "00000000000000000000000000000000000000000000000000000000000000fe",
+		ParentNum: number - 1,
+		Timestamp: timestamppb.New(blockTime),
+		Payload:   payload,
+	}))
+	return io.NopCloser(out)
+}
+
+func TestMergerIO_AnnotatesMergedBlocksOnGS(t *testing.T) {
+	blockTime := time.Date(2025, 10, 12, 10, 23, 12, 0, time.UTC)
+
+	oneBlockStore := dstore.NewMockStore(nil)
+	oneBlockStore.OpenObjectFunc = func(_ context.Context, name string) (io.ReadCloser, error) {
+		return timedBlockReader(t, 100, blockTime), nil
+	}
+
+	var written int64
+	mergedBlocksStore := newGSMockStore(func(base string, f io.Reader) error {
+		size, err := io.Copy(io.Discard, f)
+		written = size
+		return err
+	})
+
+	var annotated string
+	var metadata map[string]string
+	mergedBlocksStore.SetMetadataFunc = func(_ context.Context, base string, m map[string]string) error {
+		annotated, metadata = base, m
+		return nil
+	}
+
+	mio := NewDStoreIO(testLogger, oneBlockStore, mergedBlocksStore, nil, 0, 0, 100, 0)
+	require.NoError(t, mio.MergeAndStore(context.Background(), 100, []*bstream.OneBlockFile{block100(), block101()}))
+
+	require.NotNil(t, metadata, "the merged-blocks file should have been annotated")
+	assert.Equal(t, "0000000100", annotated)
+
+	assert.Equal(t, "2", metadata[firecore.MergedBlocksItemCountMetadataKey])
+	assert.Equal(t, "2025-10-12 10:23:12", metadata[firecore.MergedBlocksTimestampMetadataKey])
+	// The size recorded is the bundle as written, before the store compresses it.
+	assert.Equal(t, humanInt(written), metadata[firecore.MergedBlocksDataSizeMetadataKey])
+}
+
+// Every other backend keeps no metadata a listing can read back, so nothing is written there.
+func TestMergerIO_DoesNotAnnotateOffGS(t *testing.T) {
+	oneBlockStore := dstore.NewMockStore(nil)
+	oneBlockStore.OpenObjectFunc = func(_ context.Context, name string) (io.ReadCloser, error) {
+		return timedBlockReader(t, 100, time.Now()), nil
+	}
+
+	mergedBlocksStore := dstore.NewMockStore(func(base string, f io.Reader) error {
+		_, err := io.Copy(io.Discard, f)
+		return err
+	})
+
+	var annotations int
+	mergedBlocksStore.SetMetadataFunc = func(context.Context, string, map[string]string) error {
+		annotations++
+		return nil
+	}
+
+	mio := NewDStoreIO(testLogger, oneBlockStore, mergedBlocksStore, nil, 0, 0, 100, 0)
+	require.NoError(t, mio.MergeAndStore(context.Background(), 100, []*bstream.OneBlockFile{block100(), block101()}))
+
+	assert.Zero(t, annotations)
+}
+
+// A merge whose annotation cannot be written still succeeds: the bundle is there and correct,
+// only its description is missing, and the annotate tool fills that back in.
+func TestMergerIO_AnnotationFailureDoesNotFailMerge(t *testing.T) {
+	oneBlockStore := dstore.NewMockStore(nil)
+	oneBlockStore.OpenObjectFunc = func(_ context.Context, name string) (io.ReadCloser, error) {
+		return timedBlockReader(t, 100, time.Now()), nil
+	}
+
+	mergedBlocksStore := newGSMockStore(func(base string, f io.Reader) error {
+		_, err := io.Copy(io.Discard, f)
+		return err
+	})
+	mergedBlocksStore.SetMetadataFunc = func(context.Context, string, map[string]string) error {
+		return assert.AnError
+	}
+
+	mio := NewDStoreIO(testLogger, oneBlockStore, mergedBlocksStore, nil, 0, 0, 100, 0)
+	require.NoError(t, mio.MergeAndStore(context.Background(), 100, []*bstream.OneBlockFile{block100(), block101()}))
+}
+
+func humanInt(value int64) string {
+	return firecore.MergedBlocksMetadata(value, 0, time.Time{})[firecore.MergedBlocksDataSizeMetadataKey]
+}

--- a/merger/merger_io.go
+++ b/merger/merger_io.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/streamingfast/bstream"
 	"github.com/streamingfast/dstore"
+	firecore "github.com/streamingfast/firehose-core"
 	"github.com/streamingfast/firehose-core/merger/metrics"
 	"go.uber.org/zap"
 )
@@ -59,6 +60,11 @@ type DStoreIO struct {
 	oneBlocksStore    dstore.Store
 	mergedBlocksStore dstore.Store
 
+	// annotateMergedBlocks is set when the merged-blocks store keeps custom object metadata a
+	// listing can read back, which today means Google Cloud Storage. Elsewhere the annotation
+	// would cost a write per bundle and be readable by nothing.
+	annotateMergedBlocks bool
+
 	retryAttempts int
 	retryCooldown time.Duration
 
@@ -83,13 +89,14 @@ func NewDStoreIO(
 	od := &oneBlockFilesDeleter{store: oneBlocksStore, logger: logger}
 	od.Start(numDeleteThreads, DefaultFilesDeleteBatchSize*2)
 	dstoreIO := &DStoreIO{
-		oneBlocksStore:    oneBlocksStore,
-		mergedBlocksStore: mergedBlocksStore,
-		retryAttempts:     retryAttempts,
-		retryCooldown:     retryCooldown,
-		bundleSize:        bundleSize,
-		logger:            logger,
-		od:                od,
+		oneBlocksStore:       oneBlocksStore,
+		mergedBlocksStore:    mergedBlocksStore,
+		annotateMergedBlocks: firecore.MergedBlocksMetadataSupported(mergedBlocksStore),
+		retryAttempts:        retryAttempts,
+		retryCooldown:        retryCooldown,
+		bundleSize:           bundleSize,
+		logger:               logger,
+		od:                   od,
 	}
 
 	forkAware := forkedBlocksStore != nil
@@ -136,6 +143,9 @@ func (s *DStoreIO) MergeAndStore(ctx context.Context, inclusiveLowerBlock uint64
 
 	s.logger.Info("about to write merged blocks to storage location", zapFields...)
 
+	// The bundle is streamed, so its uncompressed size is only known once it is written: count
+	// it on the way through rather than reading the file back to find out.
+	var dataSize int64
 	err = Retry(s.logger, s.retryAttempts, s.retryCooldown, func() error {
 		inCtx, cancel := context.WithTimeout(ctx, WriteObjectTimeout)
 		defer cancel()
@@ -147,15 +157,67 @@ func (s *DStoreIO) MergeAndStore(ctx context.Context, inclusiveLowerBlock uint64
 		// feeding goroutine would block forever on the pipe, holding an open one-block
 		// reader on every retry. Closing the read end unblocks it so it can exit.
 		defer streamReader.Close()
-		return s.mergedBlocksStore.WriteObject(inCtx, bundleFilename, streamReader)
+
+		counter := &countingReader{ReadCloser: streamReader}
+		if err := s.mergedBlocksStore.WriteObject(inCtx, bundleFilename, counter); err != nil {
+			return err
+		}
+		dataSize = counter.count
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("write object error: %s", err)
 	}
 
+	s.annotate(ctx, bundleFilename, dataSize, filteredOBF)
+
 	s.logger.Info("merged and uploaded", zap.String("filename", fileNameForBlocksBundle(inclusiveLowerBlock)), zap.Duration("merge_time", time.Since(t0)))
 
 	return
+}
+
+// annotate records the bundle's uncompressed size, block count and first block time on the
+// object it was just written to, so a listing tells what a file holds without reading it.
+//
+// A failure here never fails the merge: the bundle is written and correct, only its description
+// is missing, and `firecore tools annotate-merged-blocks` fills that back in.
+func (s *DStoreIO) annotate(ctx context.Context, bundleFilename string, dataSize int64, oneBlockFiles []*bstream.OneBlockFile) {
+	if !s.annotateMergedBlocks || len(oneBlockFiles) == 0 {
+		return
+	}
+
+	// Reads only as far as the timestamp field of the first block, so a chain with large blocks
+	// costs no more here than a chain with small ones.
+	firstBlockTime, err := readBlockTimestamp(ctx, oneBlockFiles[0], s.OpenOneBlockFile)
+	if err != nil {
+		s.logger.Warn("cannot read first block time, leaving merged blocks file unannotated",
+			zap.String("filename", bundleFilename),
+			zap.Uint64("block_num", oneBlockFiles[0].Num),
+			zap.Error(err),
+		)
+		return
+	}
+
+	metadata := firecore.MergedBlocksMetadata(dataSize, int64(len(oneBlockFiles)), firstBlockTime)
+	if err := s.mergedBlocksStore.SetMetadata(ctx, bundleFilename, metadata); err != nil {
+		s.logger.Warn("cannot annotate merged blocks file",
+			zap.String("filename", bundleFilename),
+			zap.Error(err),
+		)
+	}
+}
+
+// countingReader counts what is read through it, which for the bundle reader is the bundle's
+// size before the store compresses it.
+type countingReader struct {
+	io.ReadCloser
+	count int64
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	r.count += int64(n)
+	return n, err
 }
 
 func (s *DStoreIO) WalkOneBlockFiles(ctx context.Context, lowestBlock uint64, callback func(*bstream.OneBlockFile) error) error {


### PR DESCRIPTION
Records what a merged-blocks file holds on the object itself, as three custom metadata entries, so a listing tells you without reading the file:

| key | value |
| --- | --- |
| `datasize` | the file's size once decompressed, in bytes |
| `itemcount` | the number of blocks it holds |
| `timestamp` | the time of its first block, `2025-10-12 10:23:12` in UTC |

Google Cloud Storage only, everywhere. No other backend keeps custom object metadata a listing reads back, so elsewhere nothing is written and nothing changes.

### The merger writes them as it uploads

The bundle is streamed, so its uncompressed size is counted on the way through rather than by reading the file back. The first block's time is read from the head of the first one-block file, far enough to reach the timestamp field and no further, so a chain with large blocks costs no more than one with small blocks.

An annotation that cannot be written never fails the merge: the bundle is written and correct, only its description is missing, and the tool below fills it back in.

### `firecore tools annotate-merged-blocks <gs-store-url>`

Backfills the same three entries on files written before the merger did it.

No block is ever held in memory: each one is read into a scratch buffer reused from block to block and from file to file, and dropped; of the first block only the head is looked at, far enough to reach its timestamp. Only the block's metadata fields are decoded, its chain-specific payload being skipped, so no chain block type is needed. `--parallelism` (32 by default) sets how many files are read at once.

Files already carrying all three entries are skipped straight from the listing, which carries their metadata, so a rerun over a mostly-done store costs one listing and nothing else — `--overwrite` recomputes them. `--start-block` and `--stop-block` bound the listing service-side, `--dry-run` reads nothing.

Reads and metadata writes are both pinned to the generation and metageneration the listing returned, so a file the merger rewrites mid-run is reported as failed rather than annotated with values from a version that is gone.

`--grpc` switches to the Cloud Storage gRPC API, which on GKE takes the DirectPath route straight to the storage backend, spread over `--grpc-connection-pool` connections (one per 32 of `--parallelism` by default). The store URL takes the same two query parameters `dstore` reads: `?project=` bills the reads to that project on a requester-pays bucket, and `?client_protocol=grpc` selects the same transport as `--grpc`. Setting a project turns DirectPath off, since DirectPath does not carry the `x-goog-user-project` header requester-pays billing needs.

### `firecore tools stats-merged-blocks <gs-store-url>`

Reports total compressed and uncompressed size, block count, compression ratio and bytes per block, broken down by month and totalled over `--start-block` to `--stop-block`.

Nothing is downloaded — every number comes from the three entries above, which come back with the listing, so the whole report costs one listing however large the range is. Files missing any of the three are counted and reported, and contribute to nothing.

```
MONTH     FILES    BLOCKS  COMPRESSED  UNCOMPRESSED  RATIO  COMP./BLOCK  UNCOMP./BLOCK
2025-08   1,000   100,000      1.2 GB        4.5 GB  3.75x        12 kB          45 kB
2025-09   1,000   100,000      1.3 GB        4.9 GB  3.77x        13 kB          49 kB

TOTAL     2,000   200,000      2.5 GB        9.4 GB  3.76x        12 kB          47 kB
```
