### PR TITLE
fix(blockpoller): only warn when client calls are actually failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 ## Unreleased
 
+### Fixed
+
+- The block poller no longer warns `no clients have been working for over 1 minute, still retrying` on slower chains like Bitcoin/Litecoin with block rate exceeding 1 minute. Instead it only warns if fetches have been actually failing for over a minute.
+
 ### Changed
 
 - `firecore tools substreams prune-states` and `prune-outputs` delete much faster: deletions now run on their own `--delete-parallelism` (250 by default) instead of sharing the listing's `--parallelism` (16 and 64), each attempt is bounded at 5s instead of 30s, and a failed deletion is retried once after 50ms instead of four times over 7.5s. A deletion that still fails is reported as before and picked up by the next run.

--- a/blockpoller/poller.go
+++ b/blockpoller/poller.go
@@ -45,8 +45,9 @@ type BlockPoller[C any] struct {
 
 	logger *zap.Logger
 
-	lastSuccessfulClientCall     time.Time
-	lastSuccessfulClientCallLock sync.Mutex
+	lastSuccessfulClientCall time.Time
+	firstFailedClientCall    time.Time
+	clientCallLock           sync.Mutex
 
 	optimisticallyPolledBlocks map[uint64]*BlockItem
 
@@ -105,15 +106,24 @@ func (p *BlockPoller[C]) Run(firstStreamableBlockNum uint64, stopBlock *uint64, 
 }
 
 func (p *BlockPoller[C]) markClientSuccess() {
-	p.lastSuccessfulClientCallLock.Lock()
+	p.clientCallLock.Lock()
 	p.lastSuccessfulClientCall = time.Now()
-	p.lastSuccessfulClientCallLock.Unlock()
+	p.firstFailedClientCall = time.Time{}
+	p.clientCallLock.Unlock()
+}
+
+func (p *BlockPoller[C]) markClientFailure() {
+	p.clientCallLock.Lock()
+	if p.firstFailedClientCall.IsZero() {
+		p.firstFailedClientCall = time.Now()
+	}
+	p.clientCallLock.Unlock()
 }
 
 func (p *BlockPoller[C]) run(resolvedStartBlock bstream.BlockRef, stopBlock uint64, blockFetchBatchSize int) (err error) {
-	p.lastSuccessfulClientCallLock.Lock()
+	p.clientCallLock.Lock()
 	p.lastSuccessfulClientCall = time.Now()
-	p.lastSuccessfulClientCallLock.Unlock()
+	p.clientCallLock.Unlock()
 
 	go func() {
 		ticker := time.NewTicker(15 * time.Second)
@@ -121,11 +131,18 @@ func (p *BlockPoller[C]) run(resolvedStartBlock bstream.BlockRef, stopBlock uint
 		for {
 			select {
 			case <-ticker.C:
-				p.lastSuccessfulClientCallLock.Lock()
+				p.clientCallLock.Lock()
+				firstFailure := p.firstFailedClientCall
 				since := time.Since(p.lastSuccessfulClientCall)
-				p.lastSuccessfulClientCallLock.Unlock()
-				if since > time.Minute {
-					p.logger.Warn("no clients have been working for over 1 minute, still retrying", zap.Duration("elapsed_since_last_success", since))
+				p.clientCallLock.Unlock()
+				if firstFailure.IsZero() {
+					continue
+				}
+				if failingFor := time.Since(firstFailure); failingFor > time.Minute {
+					p.logger.Warn("no clients have been working for over 1 minute, still retrying",
+						zap.Duration("failing_for", failingFor),
+						zap.Duration("elapsed_since_last_success", since),
+					)
 				}
 			case <-p.Terminating():
 				return
@@ -280,6 +297,7 @@ func (p *BlockPoller[C]) loadNextBlocks(requestedBlock uint64, numberOfBlockToFe
 			})
 
 			if err != nil {
+				p.markClientFailure()
 				return fmt.Errorf("fetching block %d with retry : %w", blockToFetch, err)
 			}
 			blockItem = bi
@@ -412,6 +430,7 @@ func (p *BlockPoller[C]) fetchBlockWithHash(blkNum uint64, hash string) (*pbbstr
 		})
 
 		if err != nil {
+			p.markClientFailure()
 			return fmt.Errorf("fetching block with retry %d: %w", blkNum, err)
 		}
 


### PR DESCRIPTION
On slower chains like Bitcoin/Litecoin, poller logs this warning every 15 seconds:
```
WARN (firebtc.poller) no clients have been working for over 1 minute, still retrying 
```
Basically it's treating lack of new blocks as failing RPC calls.

This PR changes the warning logic to warn only if calls are actually failing for over a minute.