### PR TITLE
Bump substreams for the eviction autoscaler metric fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 ## Unreleased
 
+### Fixed
+
+- Bumped substreams: `substreams_tier1_effective_active_requests` could read below `substreams_active_requests`, the
+  metric it is meant to replace as the horizontal autoscaler input. Requests still setting up were counted by one and
+  not the other, so a tier1 pod with requests queued in setup looked emptier to the autoscaler than it was.
+
 ### Changed
 
 - Bumped `golang.org/x/crypto` to `v0.56.0`, clearing CVE-2026-78662 and CVE-2026-56855 (both HIGH), which the Docker Scout scan of the published image fails on.

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/streamingfast/payment-gateway v0.0.0-20260527144655-d0576d2a4ee3
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0
-	github.com/streamingfast/substreams v1.22.1-0.20260903162505-4035f21109ec
+	github.com/streamingfast/substreams v1.22.1-0.20260904144249-0cb71ecc5067
 	github.com/stretchr/testify v1.12.1
 	github.com/test-go/testify v1.1.4
 	github.com/testcontainers/testcontainers-go v0.44.0

--- a/go.sum
+++ b/go.sum
@@ -2346,8 +2346,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.22.1-0.20260903162505-4035f21109ec h1:kqkkPgecmnfPQYo1+Njl5aj5AsFj4wwh4TCB0y++/Gg=
-github.com/streamingfast/substreams v1.22.1-0.20260903162505-4035f21109ec/go.mod h1:5dem5fXAtquO5oMD7Y+HW51jyIxCtF0gHSCDelBiAp8=
+github.com/streamingfast/substreams v1.22.1-0.20260904144249-0cb71ecc5067 h1:2VzveirqwAt4e/StAhtkTvL/e24vTUgXl+kz8NWBDGw=
+github.com/streamingfast/substreams v1.22.1-0.20260904144249-0cb71ecc5067/go.mod h1:IcDTsh454VcFzcahrpBildjJDUankkty+PGtEQ+ysqA=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=


### PR DESCRIPTION
Picks up streamingfast/substreams#921.

`substreams_tier1_effective_active_requests` could read below `substreams_active_requests`, the metric it is meant to replace as the horizontal autoscaler input, because requests still setting up were counted by one and not the other. A tier1 pod with requests queued in setup looked emptier to the autoscaler than it was.

**Pinned to an unmerged commit** (`0c74c9fa` on substreams `fix/eviction-autoscaler-metric-count`). Re-pin to develop once that merges, before taking this out of draft.