### PR TITLE
merger: make maxUnlinkableBlocks overridable via MERGER_MAX_UNLINKABLE_BLOCKS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 ### Added
 
+- The merger's `maxUnlinkableBlocks` circuit breaker (`bundleSize*4`) can now be overridden with the `MERGER_MAX_UNLINKABLE_BLOCKS` env var, for deployments where the default is too tight (e.g. several one-block-file writers per chain) to tolerate an ordinary reorg or brief writer hiccup. Unset or invalid values keep the existing `bundleSize*4` default.
+
 - The `Blocks` request handler now logs an `"incoming firehose Blocks request"` line as soon as a request starts, carrying `trace_id`, `organization_id`, `api_key_id`, `real_ip`, `start_block`, `stop_block`, `final_blocks_only` and `cursor`. The existing `"firehose process completed"` line gains `duration` (total request time), `time_to_first_data` and `first_sent_block` (zero-valued if no block was ever sent). Both lines are now emitted for every request outcome, including early rejections (session denied, rate limited, unimplemented transforms) and client disconnects, so every request can be paired up downstream by `trace_id`. A client-initiated cancellation is logged with `error: "context canceled"`; a server-initiated one (e.g. a revoked session) logs its real cause instead of collapsing into the same bucket.
 
 - The merger now records what a merged-blocks file holds on the object itself, as three custom metadata entries written as it uploads each bundle: `datasize`, the file's size once decompressed, `itemcount`, the number of blocks it holds, and `timestamp`, the time of its first block written as `2025-10-12 10:23:12` in UTC. A listing then tells what a file holds without reading it.

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -18,6 +18,22 @@ func GetEnvForceFinalityAfterBlocks() *uint64 {
 	return nil
 }
 
+// GetEnvMergerMaxUnlinkableBlocks reads MERGER_MAX_UNLINKABLE_BLOCKS, the operator override for
+// the merger's maxUnlinkableBlocks circuit breaker (normally bundleSize*4 — see merger.run()).
+// Deployments running many one-block-file writers (readers/relayers), or chains fast enough
+// that bundleSize*4 blocks cover only a few seconds of real time, can exceed that default
+// during an ordinary reorg or brief writer hiccup and fatally crash-loop the merger. Returns nil
+// (caller keeps its own default) if unset or invalid.
+func GetEnvMergerMaxUnlinkableBlocks() *int {
+	if max := os.Getenv("MERGER_MAX_UNLINKABLE_BLOCKS"); max != "" {
+		if max64, err := strconv.ParseInt(max, 10, 64); err == nil {
+			maxInt := int(max64)
+			return &maxInt
+		}
+	}
+	return nil
+}
+
 func TweakBlockFinality(blk *pbbstream.Block, maxDistanceToBlock uint64) {
 	if blk.LibNum > blk.Number {
 		distance := blk.LibNum - blk.Number

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -26,6 +26,24 @@ func TestGetEnvForceFinalityAfterBlocks(t *testing.T) {
 		t.Errorf("Expected %d, got %d", expected, *result)
 	}
 }
+func TestGetEnvMergerMaxUnlinkableBlocks(t *testing.T) {
+	// unset: caller should get nil and fall back to its own default
+	os.Unsetenv("MERGER_MAX_UNLINKABLE_BLOCKS")
+	assert.Nil(t, GetEnvMergerMaxUnlinkableBlocks())
+
+	// set: caller should get the override
+	expected := 4000
+	os.Setenv("MERGER_MAX_UNLINKABLE_BLOCKS", strconv.Itoa(expected))
+	defer os.Unsetenv("MERGER_MAX_UNLINKABLE_BLOCKS")
+
+	result := GetEnvMergerMaxUnlinkableBlocks()
+	if result == nil {
+		t.Errorf("Expected non-nil result, got nil")
+	} else if *result != expected {
+		t.Errorf("Expected %d, got %d", expected, *result)
+	}
+}
+
 func TestTweakBlockFinality(t *testing.T) {
 	// Define test cases
 	testCases := []struct {

--- a/merger/merger.go
+++ b/merger/merger.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/streamingfast/bstream"
+	"github.com/streamingfast/firehose-core/internal/utils"
 	"github.com/streamingfast/shutter"
 	"go.uber.org/zap"
 )
@@ -227,6 +228,9 @@ func (m *Merger) run() error {
 
 		unlinkableCount := 0
 		maxUnlinkableBlocks := int(m.bundler.bundleSize * 4)
+		if override := utils.GetEnvMergerMaxUnlinkableBlocks(); override != nil {
+			maxUnlinkableBlocks = *override
+		}
 		lastBase := m.bundler.baseBlockNum
 
 		err = m.io.WalkOneBlockFiles(ctx, base, func(obf *bstream.OneBlockFile) error {

--- a/merger/merger_run_test.go
+++ b/merger/merger_run_test.go
@@ -212,6 +212,65 @@ func TestMergerRun_HoleInOneBlockFiles_TriggersCheckLoop(t *testing.T) {
 	assert.GreaterOrEqual(t, walkCallCount, 2, "expected multiple walk calls: errCheckLoop should cause retries, not shutdown")
 }
 
+// TestMergerRun_MaxUnlinkableBlocksEnvOverride verifies that MERGER_MAX_UNLINKABLE_BLOCKS
+// raises the maxUnlinkableBlocks circuit breaker above its bundleSize*4 default, letting the
+// merger walk through a gap that would otherwise trip errCheckLoop — same gap as
+// TestMergerRun_HoleInOneBlockFiles_TriggersCheckLoop, just with the override set.
+func TestMergerRun_MaxUnlinkableBlocksEnvOverride(t *testing.T) {
+	const bundleSize = uint64(10) // default maxUnlinkableBlocks = 40, overridden to 100 below
+
+	t.Setenv("MERGER_MAX_UNLINKABLE_BLOCKS", "100")
+
+	// same gap as TestMergerRun_HoleInOneBlockFiles_TriggersCheckLoop: bundle 10-19 complete,
+	// then a 40+ block gap before 61-120 — enough to trip the default 40 limit, not the
+	// overridden 100.
+	var allBlocks []*bstream.OneBlockFile
+	allBlocks = append(allBlocks, buildChain(10, 19, nil)...)
+	allBlocks = append(allBlocks, buildChain(61, 120, nil)...)
+
+	checkLoopTriggered := false
+	walkCallCount := 0
+	var merger *Merger
+
+	testIO := &TestMergerIO{
+		NextBundleFunc: func(_ context.Context, lowestBaseBlock uint64) (uint64, bstream.BlockRef, error) {
+			if lowestBaseBlock < 10 {
+				return 10, libRef(9), nil
+			}
+			return lowestBaseBlock, nil, nil
+		},
+		WalkOneBlockFilesFunc: func(_ context.Context, inclusiveLowerBlock uint64, callback func(*bstream.OneBlockFile) error) error {
+			walkCallCount++
+			if walkCallCount >= 3 {
+				merger.Shutdown(nil)
+				return nil
+			}
+			for _, blk := range allBlocks {
+				if blk.Num < inclusiveLowerBlock {
+					continue
+				}
+				if err := callback(blk); err != nil {
+					if errors.Is(err, errCheckLoop) {
+						checkLoopTriggered = true
+					}
+					return err
+				}
+			}
+			return nil
+		},
+		MergeAndStoreFunc: func(_ context.Context, _ uint64, _ []*bstream.OneBlockFile) error {
+			return nil
+		},
+	}
+
+	merger = newRunTestMerger(testIO, 0, bundleSize, 1)
+	err := merger.run()
+	require.NoError(t, err)
+	merger.bundler.WaitForMerges()
+
+	assert.False(t, checkLoopTriggered, "errCheckLoop must not trigger once the override raises maxUnlinkableBlocks above the gap size")
+}
+
 // TestMergerRun_LargeLibJumpDoesNotTriggerCheckLoop verifies that a LIB jump much larger
 // than bundleSize*4 (590 >> 40) firing many bundles at once does NOT trigger errCheckLoop.
 //


### PR DESCRIPTION
## Summary

`maxUnlinkableBlocks` (`merger.go`'s `bundleSize*4` circuit breaker on consecutive unlinkable
one-block-files during a walk) is currently a fixed multiple of `BundleSize` with no way to
raise it independently. We hit this in production on a chain running more than the usual
number of one-block-file writers per chain (several `sf_reader`/`sf_relayer` instances, each
writing its own uniquely-suffixed one-block-files) — with `BundleSize=100` (the 400-block
default), an ordinary reorg or brief writer hiccup was enough to exceed 400 consecutive
unlinkable entries in a single walk, tripping `errCheckLoop` repeatedly and — combined with a
separate error-wrapping issue that causes consecutive `errCheckLoop` occurrences to count
toward the merger's fatal `too many consecutive errors` shutdown — crash-looping the merger
roughly every 8 minutes.

Raising `BundleSize` itself is one lever, but it also changes merged-file granularity, which
isn't always desirable. This adds `MERGER_MAX_UNLINKABLE_BLOCKS` as an independent operator
override, following the existing `FORCE_FINALITY_AFTER_BLOCKS` pattern already used in
`internal/utils` for exactly this kind of "env var overrides a default, nil/unset means keep
current behavior" case.

- `internal/utils.GetEnvMergerMaxUnlinkableBlocks()` — reads `MERGER_MAX_UNLINKABLE_BLOCKS`,
  returns `nil` if unset or invalid (mirrors `GetEnvForceFinalityAfterBlocks`).
- `merger.run()` uses the override when present, otherwise keeps the existing `bundleSize*4`
  default — no behavior change unless the env var is explicitly set.

## Test plan

- [x] `go test ./internal/utils/... ./merger/...` — all existing tests pass unchanged
- [x] New `TestGetEnvMergerMaxUnlinkableBlocks` (mirrors `TestGetEnvForceFinalityAfterBlocks`)
- [x] New `TestMergerRun_MaxUnlinkableBlocksEnvOverride`: reuses the exact gap scenario from
      `TestMergerRun_HoleInOneBlockFiles_TriggersCheckLoop` (which trips `errCheckLoop` at the
      default 40-block limit for `bundleSize=10`) and confirms setting
      `MERGER_MAX_UNLINKABLE_BLOCKS=100` lets the merger walk through the same gap without
      triggering `errCheckLoop`
- [x] `go build ./...` and `go vet ./...` clean (one pre-existing, unrelated `go vet` warning
      in `firehose/client/example/main.go`, not touched by this change)