### PR TITLE
Bump substreams to fix partial-block undo sequence on tier1 shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 - Bumped substreams: `substreams_tier1_effective_active_requests` could read below `substreams_active_requests`, the
   metric it is meant to replace as the horizontal autoscaler input. Requests still setting up were counted by one and
   not the other, so a tier1 pod with requests queued in setup looked emptier to the autoscaler than it was.
+- Bumped substreams: fixed handling of partial-blocks (flashblocks) streams on a tier1 that is shutting down. The
+  stream now ends with `Unavailable` like a full-block stream does, so the client reconnects elsewhere. It used to
+  stay open but silent, then send an undo signal at each block boundary naming a block the client had never
+  received. An undo signal is also no longer sent for partial-block state whose outputs were never sent.
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/streamingfast/payment-gateway v0.0.0-20260527144655-d0576d2a4ee3
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0
-	github.com/streamingfast/substreams v1.22.1-0.20260904144249-0cb71ecc5067
+	github.com/streamingfast/substreams v1.22.1-0.20260908190533-360e41fbc42f
 	github.com/stretchr/testify v1.12.1
 	github.com/test-go/testify v1.1.4
 	github.com/testcontainers/testcontainers-go v0.44.0

--- a/go.sum
+++ b/go.sum
@@ -2346,8 +2346,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.22.1-0.20260904144249-0cb71ecc5067 h1:2VzveirqwAt4e/StAhtkTvL/e24vTUgXl+kz8NWBDGw=
-github.com/streamingfast/substreams v1.22.1-0.20260904144249-0cb71ecc5067/go.mod h1:IcDTsh454VcFzcahrpBildjJDUankkty+PGtEQ+ysqA=
+github.com/streamingfast/substreams v1.22.1-0.20260908190533-360e41fbc42f h1:XITgRK5HWF0D13jHiHYP/Rt7ArhVYK7ik74wQAMPUuw=
+github.com/streamingfast/substreams v1.22.1-0.20260908190533-360e41fbc42f/go.mod h1:IcDTsh454VcFzcahrpBildjJDUankkty+PGtEQ+ysqA=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=


### PR DESCRIPTION
Bumps `substreams` to [v1.22.1-0.20260908190533-360e41fbc42f](https://github.com/streamingfast/substreams/compare/0cb71ecc5067...360e41fbc42f), pulling in the fix for tier1 sending an invalid UNDO sequence when a partial-block stream is up during pod shutdown.