### PR TITLE
Stop acting on undo signals in reader-node-firehose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 ### Fixed
 
 - Bumped `google.golang.org/grpc` to v1.83.2, which fixes CVE-2026-84445.
+- `reader-node-firehose` no longer acts on undo signals from its upstream endpoint. It treated a `STEP_UNDO` response like a new block and re-emitted it, now it just logs and skips them. (a reader does not take decisions on reorgs)
 - The block poller no longer warns `no clients have been working for over 1 minute, still retrying` on slower chains like Bitcoin/Litecoin with block rate exceeding 1 minute. Instead it only warns if fetches have been actually failing for over a minute.
 - Bumped substreams: `substreams_tier1_effective_active_requests` could read below `substreams_active_requests`, the
   metric it is meant to replace as the horizontal autoscaler input. Requests still setting up were counted by one and
@@ -23,6 +24,8 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
   received. An undo signal is also no longer sent for partial-block state whose outputs were never sent.
 
 ### Changed
+
+- Removed the `--reader-node-firehose-compression` flag. It has never had any effect: the connection to the upstream endpoint always uses zstd. Operators setting it must drop it, as an unknown flag stops the process from starting.
 
 - Bumped `golang.org/x/crypto` to `v0.56.0`, clearing CVE-2026-78662 and CVE-2026-56855 (both HIGH), which the Docker Scout scan of the published image fails on.
 

--- a/cmd/apps/reader_node_firehose.go
+++ b/cmd/apps/reader_node_firehose.go
@@ -38,7 +38,6 @@ func RegisterReaderNodeFirehoseApp[B firecore.Block](chain *firecore.Chain[B], r
 		RegisterFlags: func(cmd *cobra.Command) error {
 			cmd.Flags().String("reader-node-firehose-endpoint", "", "Firehose endpoint to connect to.")
 			cmd.Flags().String("reader-node-firehose-state", "{data-dir}/reader/state", "State file to store the cursor from the Firehose connection in.")
-			cmd.Flags().String("reader-node-firehose-compression", "zstd", "Firehose compression, one of 'gzip', 'zstd' or 'none'.")
 			cmd.Flags().Bool("reader-node-firehose-insecure", false, "Skip TLS validation when connecting to a Firehose endpoint.")
 			cmd.Flags().Bool("reader-node-firehose-plaintext", false, "Connect to a Firehose endpoint using a non-encrypted, plaintext connection.")
 			cmd.Flags().String("reader-node-firehose-api-key-env-var", "FIREHOSE_API_KEY", "Look for an API key directly in this environment variable to authenticate against endpoint (alternative to api-token-env-var)")
@@ -81,7 +80,6 @@ func RegisterReaderNodeFirehoseApp[B firecore.Block](chain *firecore.Chain[B], r
 					Endpoint:      viper.GetString("reader-node-firehose-endpoint"),
 					InsecureConn:  viper.GetBool("reader-node-firehose-insecure"),
 					PlaintextConn: viper.GetBool("reader-node-firehose-plaintext"),
-					Compression:   viper.GetString("reader-node-firehose-compression"),
 				},
 			}, testModeComparator, appLogger, appTracer), nil
 		},

--- a/node-manager/app/firehose_reader/app.go
+++ b/node-manager/app/firehose_reader/app.go
@@ -52,7 +52,6 @@ type FirehoseConfig struct {
 	ApiKey        string
 	ApiToken      string
 	Endpoint      string
-	Compression   string
 	PlaintextConn bool
 	InsecureConn  bool
 }

--- a/node-manager/app/firehose_reader/syncer.go
+++ b/node-manager/app/firehose_reader/syncer.go
@@ -143,6 +143,14 @@ func (s *syncer) Run() error {
 				break
 			}
 
+			if response.Step == pbfirehose.ForkStep_STEP_UNDO {
+				s.logger.Info("skipping undo block, the one-block file for it was already written and the reorg is resolved downstream",
+					zap.Uint64("block_num", response.Metadata.Num),
+					zap.String("block_id", response.Metadata.Id),
+				)
+				continue
+			}
+
 			pbBlock := &pbbstream.Block{
 				Number:    response.Metadata.Num,
 				Id:        response.Metadata.Id,


### PR DESCRIPTION
1. Skip (and log) undo responses:

`reader-node-firehose` never read `response.Step`, so a `STEP_UNDO` response took the exact same path as a new block: it rewrote the one-block file, re-announced the block on the app's own block stream to the relayer, and moved `head_block_number` and `finalized_block_number` back to the undone block. This is wasted effort.


2. Remove unused `--reader-node-firehose-compression` flag. It was read into the config and never used; (the connection always sets `grpc.UseCompressor(zstd.Name)`)