### PR TITLE
Show the first block of each month in stats-merged-blocks, also use TiB not TB

### DIFF
--- a/cmd/tools/mergeblock/tools_annotate_merged_blocks.go
+++ b/cmd/tools/mergeblock/tools_annotate_merged_blocks.go
@@ -205,7 +205,7 @@ func runAnnotateMergedBlocks(ctx context.Context, storeURL string, cfg annotateC
 	}
 	fmt.Println(stylex.Valuef("%s %d file(s), %s block(s)", annotatedLabel, stats.annotated.Load(), humanize.Comma(stats.blocks.Load())))
 	fmt.Println(stylex.Valuef("Skipped:     %d file(s) already carrying all three entries", stats.skipped.Load()))
-	fmt.Println(stylex.Valuef("Read:        %s compressed, %s uncompressed", humanize.Bytes(uint64(stats.compressed.Load())), humanize.Bytes(uint64(stats.uncompressed.Load()))))
+	fmt.Println(stylex.Valuef("Read:        %s compressed, %s uncompressed", humanize.IBytes(uint64(stats.compressed.Load())), humanize.IBytes(uint64(stats.uncompressed.Load()))))
 	fmt.Println(stylex.Valuef("Elapsed:     %s", time.Since(started).Round(time.Second)))
 
 	if listErr != nil {
@@ -433,7 +433,7 @@ func startAnnotateProgress(ctx context.Context, stats *annotateStats, started ti
 					zap.Int64("annotated", annotated),
 					zap.Int64("skipped", stats.skipped.Load()),
 					zap.Int64("failed", stats.failed.Load()),
-					zap.String("uncompressed", humanize.Bytes(uint64(stats.uncompressed.Load()))),
+					zap.String("uncompressed", humanize.IBytes(uint64(stats.uncompressed.Load()))),
 					zap.Float64("files_per_second", float64(annotated)/time.Since(started).Seconds()),
 				)
 			}

--- a/cmd/tools/mergeblock/tools_stats_merged_blocks.go
+++ b/cmd/tools/mergeblock/tools_stats_merged_blocks.go
@@ -125,14 +125,14 @@ type mergedBlocksTally struct {
 	blocks       int64
 	compressed   int64
 	uncompressed int64
-	// startBlock is the lowest first-block of the files in the bucket, meaningless while
+	// firstBlock is the lowest first-block of the files in the bucket, meaningless while
 	// files is 0.
-	startBlock uint64
+	firstBlock uint64
 }
 
 func (t *mergedBlocksTally) add(other mergedBlocksTally) {
-	if other.files > 0 && (t.files == 0 || other.startBlock < t.startBlock) {
-		t.startBlock = other.startBlock
+	if other.files > 0 && (t.files == 0 || other.firstBlock < t.firstBlock) {
+		t.firstBlock = other.firstBlock
 	}
 	t.files += other.files
 	t.blocks += other.blocks
@@ -265,7 +265,7 @@ type statsReport struct {
 
 type statsBucket struct {
 	Month                     string  `json:"month,omitempty"`
-	StartBlock                uint64  `json:"start_block"`
+	FirstBlock                uint64  `json:"first_block"`
 	Files                     int64   `json:"files"`
 	Blocks                    int64   `json:"blocks"`
 	CompressedBytes           int64   `json:"compressed_bytes"`
@@ -278,7 +278,7 @@ type statsBucket struct {
 func newStatsBucket(month string, tally mergedBlocksTally) statsBucket {
 	return statsBucket{
 		Month:                     month,
-		StartBlock:                tally.startBlock,
+		FirstBlock:                tally.firstBlock,
 		Files:                     tally.files,
 		Blocks:                    tally.blocks,
 		CompressedBytes:           tally.compressed,
@@ -345,7 +345,7 @@ func readAnnotation(object mergedBlocksObject) (annotatedFile, bool) {
 			blocks:       blocks,
 			compressed:   object.attrs.Size,
 			uncompressed: dataSize,
-			startBlock:   object.lowBlockNum,
+			firstBlock:   object.lowBlockNum,
 		},
 	}, true
 }
@@ -358,7 +358,7 @@ func printMergedBlocksTable(months map[string]*mergedBlocksTally, total mergedBl
 	sort.Strings(names)
 
 	table := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', tabwriter.AlignRight)
-	fmt.Fprintln(table, "MONTH\tSTART_BLOCK\tFILES\tBLOCKS\tCOMPRESSED\tUNCOMPRESSED\tRATIO\tCOMP./BLOCK\tUNCOMP./BLOCK\t")
+	fmt.Fprintln(table, "MONTH\tFIRST_BLOCK\tFILES\tBLOCKS\tCOMPRESSED\tUNCOMPRESSED\tRATIO\tCOMP./BLOCK\tUNCOMP./BLOCK\t")
 	for _, name := range names {
 		printMergedBlocksRow(table, name, *months[name])
 	}
@@ -372,7 +372,7 @@ func printMergedBlocksTable(months map[string]*mergedBlocksTally, total mergedBl
 func printMergedBlocksRow(table *tabwriter.Writer, name string, tally mergedBlocksTally) {
 	fmt.Fprintf(table, "%s\t%s\t%s\t%s\t%s\t%s\t%.2fx\t%s\t%s\t\n",
 		name,
-		humanize.Comma(int64(tally.startBlock)),
+		humanize.Comma(int64(tally.firstBlock)),
 		humanize.Comma(tally.files),
 		humanize.Comma(tally.blocks),
 		humanize.IBytes(uint64(tally.compressed)),

--- a/cmd/tools/mergeblock/tools_stats_merged_blocks.go
+++ b/cmd/tools/mergeblock/tools_stats_merged_blocks.go
@@ -125,9 +125,15 @@ type mergedBlocksTally struct {
 	blocks       int64
 	compressed   int64
 	uncompressed int64
+	// startBlock is the lowest first-block of the files in the bucket, meaningless while
+	// files is 0.
+	startBlock uint64
 }
 
 func (t *mergedBlocksTally) add(other mergedBlocksTally) {
+	if other.files > 0 && (t.files == 0 || other.startBlock < t.startBlock) {
+		t.startBlock = other.startBlock
+	}
 	t.files += other.files
 	t.blocks += other.blocks
 	t.compressed += other.compressed
@@ -259,6 +265,7 @@ type statsReport struct {
 
 type statsBucket struct {
 	Month                     string  `json:"month,omitempty"`
+	StartBlock                uint64  `json:"start_block"`
 	Files                     int64   `json:"files"`
 	Blocks                    int64   `json:"blocks"`
 	CompressedBytes           int64   `json:"compressed_bytes"`
@@ -271,6 +278,7 @@ type statsBucket struct {
 func newStatsBucket(month string, tally mergedBlocksTally) statsBucket {
 	return statsBucket{
 		Month:                     month,
+		StartBlock:                tally.startBlock,
 		Files:                     tally.files,
 		Blocks:                    tally.blocks,
 		CompressedBytes:           tally.compressed,
@@ -337,6 +345,7 @@ func readAnnotation(object mergedBlocksObject) (annotatedFile, bool) {
 			blocks:       blocks,
 			compressed:   object.attrs.Size,
 			uncompressed: dataSize,
+			startBlock:   object.lowBlockNum,
 		},
 	}, true
 }
@@ -349,20 +358,21 @@ func printMergedBlocksTable(months map[string]*mergedBlocksTally, total mergedBl
 	sort.Strings(names)
 
 	table := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', tabwriter.AlignRight)
-	fmt.Fprintln(table, "MONTH\tFILES\tBLOCKS\tCOMPRESSED\tUNCOMPRESSED\tRATIO\tCOMP./BLOCK\tUNCOMP./BLOCK\t")
+	fmt.Fprintln(table, "MONTH\tSTART_BLOCK\tFILES\tBLOCKS\tCOMPRESSED\tUNCOMPRESSED\tRATIO\tCOMP./BLOCK\tUNCOMP./BLOCK\t")
 	for _, name := range names {
 		printMergedBlocksRow(table, name, *months[name])
 	}
 	if len(names) > 1 {
-		fmt.Fprintln(table, "\t\t\t\t\t\t\t\t")
+		fmt.Fprintln(table, "\t\t\t\t\t\t\t\t\t")
 		printMergedBlocksRow(table, "TOTAL", total)
 	}
 	table.Flush()
 }
 
 func printMergedBlocksRow(table *tabwriter.Writer, name string, tally mergedBlocksTally) {
-	fmt.Fprintf(table, "%s\t%s\t%s\t%s\t%s\t%.2fx\t%s\t%s\t\n",
+	fmt.Fprintf(table, "%s\t%s\t%s\t%s\t%s\t%s\t%.2fx\t%s\t%s\t\n",
 		name,
+		humanize.Comma(int64(tally.startBlock)),
 		humanize.Comma(tally.files),
 		humanize.Comma(tally.blocks),
 		humanize.Bytes(uint64(tally.compressed)),

--- a/cmd/tools/mergeblock/tools_stats_merged_blocks.go
+++ b/cmd/tools/mergeblock/tools_stats_merged_blocks.go
@@ -375,11 +375,11 @@ func printMergedBlocksRow(table *tabwriter.Writer, name string, tally mergedBloc
 		humanize.Comma(int64(tally.startBlock)),
 		humanize.Comma(tally.files),
 		humanize.Comma(tally.blocks),
-		humanize.Bytes(uint64(tally.compressed)),
-		humanize.Bytes(uint64(tally.uncompressed)),
+		humanize.IBytes(uint64(tally.compressed)),
+		humanize.IBytes(uint64(tally.uncompressed)),
 		tally.compressionRatio(),
-		humanize.Bytes(uint64(tally.compressedPerBlock())),
-		humanize.Bytes(uint64(tally.uncompressedPerBlock())),
+		humanize.IBytes(uint64(tally.compressedPerBlock())),
+		humanize.IBytes(uint64(tally.uncompressedPerBlock())),
 	)
 }
 

--- a/cmd/tools/mergeblock/tools_stats_merged_blocks_test.go
+++ b/cmd/tools/mergeblock/tools_stats_merged_blocks_test.go
@@ -26,7 +26,7 @@ func TestReadAnnotation(t *testing.T) {
 			metadata:    map[string]string{dataSizeMetadataKey: "4096", itemCountMetadataKey: "100", timestampMetadataKey: "2025-10-12 10:23:12"},
 			expect: annotatedFile{
 				month: "2025-10",
-				tally: mergedBlocksTally{files: 1, blocks: 100, compressed: 1000, uncompressed: 4096, startBlock: 10123000},
+				tally: mergedBlocksTally{files: 1, blocks: 100, compressed: 1000, uncompressed: 4096, firstBlock: 10123000},
 			},
 			expectOK: true,
 		},
@@ -63,11 +63,11 @@ func TestReadAnnotation(t *testing.T) {
 
 func TestMergedBlocksTally(t *testing.T) {
 	var tally mergedBlocksTally
-	tally.add(mergedBlocksTally{files: 1, blocks: 100, compressed: 1000, uncompressed: 4000, startBlock: 200})
-	tally.add(mergedBlocksTally{files: 1, blocks: 100, compressed: 1000, uncompressed: 2000, startBlock: 100})
+	tally.add(mergedBlocksTally{files: 1, blocks: 100, compressed: 1000, uncompressed: 4000, firstBlock: 200})
+	tally.add(mergedBlocksTally{files: 1, blocks: 100, compressed: 1000, uncompressed: 2000, firstBlock: 100})
 
 	// The bucket takes the lowest first-block of the files added to it, whatever the order.
-	assert.Equal(t, mergedBlocksTally{files: 2, blocks: 200, compressed: 2000, uncompressed: 6000, startBlock: 100}, tally)
+	assert.Equal(t, mergedBlocksTally{files: 2, blocks: 200, compressed: 2000, uncompressed: 6000, firstBlock: 100}, tally)
 	assert.Equal(t, 3.0, tally.compressionRatio())
 	assert.Equal(t, 30.0, tally.uncompressedPerBlock())
 	assert.Equal(t, 10.0, tally.compressedPerBlock())
@@ -87,10 +87,10 @@ func TestDescribeBlockRange(t *testing.T) {
 
 func TestNewStatsReport(t *testing.T) {
 	months := map[string]*mergedBlocksTally{
-		"2025-11": {files: 1, blocks: 100, compressed: 1000, uncompressed: 2000, startBlock: 1800},
-		"2025-10": {files: 2, blocks: 200, compressed: 2000, uncompressed: 6000, startBlock: 1000},
+		"2025-11": {files: 1, blocks: 100, compressed: 1000, uncompressed: 2000, firstBlock: 1800},
+		"2025-10": {files: 2, blocks: 200, compressed: 2000, uncompressed: 6000, firstBlock: 1000},
 	}
-	total := mergedBlocksTally{files: 3, blocks: 300, compressed: 3000, uncompressed: 8000, startBlock: 1000}
+	total := mergedBlocksTally{files: 3, blocks: 300, compressed: 3000, uncompressed: 8000, firstBlock: 1000}
 	cfg := statsConfig{startBlock: 1000, stopBlock: 2000, chainName: "eth-mainnet"}
 
 	report := newStatsReport(cfg, months, total, false, 1000, 1900, 4, 1500*time.Millisecond)
@@ -111,7 +111,7 @@ func TestNewStatsReport(t *testing.T) {
 	assert.Equal(t, "2025-11", report.Months[1].Month)
 	assert.Equal(t, statsBucket{
 		Month:                     "2025-10",
-		StartBlock:                1000,
+		FirstBlock:                1000,
 		Files:                     2,
 		Blocks:                    200,
 		CompressedBytes:           2000,

--- a/cmd/tools/mergeblock/tools_stats_merged_blocks_test.go
+++ b/cmd/tools/mergeblock/tools_stats_merged_blocks_test.go
@@ -12,19 +12,21 @@ import (
 
 func TestReadAnnotation(t *testing.T) {
 	tests := []struct {
-		name     string
-		size     int64
-		metadata map[string]string
-		expect   annotatedFile
-		expectOK bool
+		name        string
+		size        int64
+		lowBlockNum uint64
+		metadata    map[string]string
+		expect      annotatedFile
+		expectOK    bool
 	}{
 		{
-			name:     "complete",
-			size:     1000,
-			metadata: map[string]string{dataSizeMetadataKey: "4096", itemCountMetadataKey: "100", timestampMetadataKey: "2025-10-12 10:23:12"},
+			name:        "complete",
+			size:        1000,
+			lowBlockNum: 10123000,
+			metadata:    map[string]string{dataSizeMetadataKey: "4096", itemCountMetadataKey: "100", timestampMetadataKey: "2025-10-12 10:23:12"},
 			expect: annotatedFile{
 				month: "2025-10",
-				tally: mergedBlocksTally{files: 1, blocks: 100, compressed: 1000, uncompressed: 4096},
+				tally: mergedBlocksTally{files: 1, blocks: 100, compressed: 1000, uncompressed: 4096, startBlock: 10123000},
 			},
 			expectOK: true,
 		},
@@ -48,7 +50,7 @@ func TestReadAnnotation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			object := mergedBlocksObject{attrs: &storage.ObjectAttrs{Size: test.size, Metadata: test.metadata}}
+			object := mergedBlocksObject{attrs: &storage.ObjectAttrs{Size: test.size, Metadata: test.metadata}, lowBlockNum: test.lowBlockNum}
 
 			file, ok := readAnnotation(object)
 			require.Equal(t, test.expectOK, ok)
@@ -61,10 +63,11 @@ func TestReadAnnotation(t *testing.T) {
 
 func TestMergedBlocksTally(t *testing.T) {
 	var tally mergedBlocksTally
-	tally.add(mergedBlocksTally{files: 1, blocks: 100, compressed: 1000, uncompressed: 4000})
-	tally.add(mergedBlocksTally{files: 1, blocks: 100, compressed: 1000, uncompressed: 2000})
+	tally.add(mergedBlocksTally{files: 1, blocks: 100, compressed: 1000, uncompressed: 4000, startBlock: 200})
+	tally.add(mergedBlocksTally{files: 1, blocks: 100, compressed: 1000, uncompressed: 2000, startBlock: 100})
 
-	assert.Equal(t, mergedBlocksTally{files: 2, blocks: 200, compressed: 2000, uncompressed: 6000}, tally)
+	// The bucket takes the lowest first-block of the files added to it, whatever the order.
+	assert.Equal(t, mergedBlocksTally{files: 2, blocks: 200, compressed: 2000, uncompressed: 6000, startBlock: 100}, tally)
 	assert.Equal(t, 3.0, tally.compressionRatio())
 	assert.Equal(t, 30.0, tally.uncompressedPerBlock())
 	assert.Equal(t, 10.0, tally.compressedPerBlock())
@@ -84,10 +87,10 @@ func TestDescribeBlockRange(t *testing.T) {
 
 func TestNewStatsReport(t *testing.T) {
 	months := map[string]*mergedBlocksTally{
-		"2025-11": {files: 1, blocks: 100, compressed: 1000, uncompressed: 2000},
-		"2025-10": {files: 2, blocks: 200, compressed: 2000, uncompressed: 6000},
+		"2025-11": {files: 1, blocks: 100, compressed: 1000, uncompressed: 2000, startBlock: 1800},
+		"2025-10": {files: 2, blocks: 200, compressed: 2000, uncompressed: 6000, startBlock: 1000},
 	}
-	total := mergedBlocksTally{files: 3, blocks: 300, compressed: 3000, uncompressed: 8000}
+	total := mergedBlocksTally{files: 3, blocks: 300, compressed: 3000, uncompressed: 8000, startBlock: 1000}
 	cfg := statsConfig{startBlock: 1000, stopBlock: 2000, chainName: "eth-mainnet"}
 
 	report := newStatsReport(cfg, months, total, false, 1000, 1900, 4, 1500*time.Millisecond)
@@ -108,6 +111,7 @@ func TestNewStatsReport(t *testing.T) {
 	assert.Equal(t, "2025-11", report.Months[1].Month)
 	assert.Equal(t, statsBucket{
 		Month:                     "2025-10",
+		StartBlock:                1000,
 		Files:                     2,
 		Blocks:                    200,
 		CompressedBytes:           2000,


### PR DESCRIPTION
Adds a `START_BLOCK` column to the `stats-merged-blocks` table, second, between `MONTH` and `FILES`: the lowest first-block of the files counted in that month, and the lowest of the whole range on the `TOTAL` row. The JSON buckets carry the same value as `start_block`.

Also, use TiB and GiB instead of TB/GB