### PR TITLE
fix(merger): stop spinning on unlinkable check loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 ### Fixed
 
+- The merger no longer spins when a walk over one-block files keeps hitting the unlinkable-blocks limit: that path skipped the `merger-time-between-store-lookups` delay, so a merger stuck behind a gap in one-block files re-walked and logged `too many unlinkable blocks, continuing to next loop` about ten times per second. It now waits like any other iteration, the line is logged at `Warn` instead of `Info`, and the wait is interrupted by shutdown.
 - Bumped `google.golang.org/grpc` to v1.83.2, which fixes CVE-2026-84445.
 - `reader-node-firehose` no longer acts on undo signals from its upstream endpoint. It treated a `STEP_UNDO` response like a new block and re-emitted it, now it just logs and skips them. (a reader does not take decisions on reorgs)
 - The block poller no longer warns `no clients have been working for over 1 minute, still retrying` on slower chains like Bitcoin/Litecoin with block rate exceeding 1 minute. Instead it only warns if fetches have been actually failing for over a minute.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 - Bumped `bstream` to enable parallel one-blocks downloading upon bootstrap or reconnect (very useful on fast chains)
 
+- Block poller per-block lines (`about to fetch block`, `requesting block`, `optimistically fetching block`, `block was optimistically polled`, `fetching block with hash`, `processing block`, `saved cursor`) are now logged at `Debug`; they fired several times per block at `Info`.
 - Removed the `--reader-node-firehose-compression` flag. It has never had any effect: the connection to the upstream endpoint always uses zstd. Operators setting it must drop it, as an unknown flag stops the process from starting.
 
 - Bumped `golang.org/x/crypto` to `v0.56.0`, clearing CVE-2026-78662 and CVE-2026-56855 (both HIGH), which the Docker Scout scan of the published image fails on.

--- a/blockpoller/poller.go
+++ b/blockpoller/poller.go
@@ -175,7 +175,7 @@ func (p *BlockPoller[C]) run(resolvedStartBlock bstream.BlockRef, stopBlock uint
 			}
 		}
 
-		p.logger.Info("about to fetch block", zap.Uint64("block_to_fetch", blockToFetch), zap.Duration("delay", delay), zap.Bool("keep", false))
+		p.logger.Debug("about to fetch block", zap.Uint64("block_to_fetch", blockToFetch), zap.Duration("delay", delay), zap.Bool("keep", false))
 		if delay != 0 {
 			time.Sleep(delay)
 		}
@@ -213,7 +213,7 @@ func (p *BlockPoller[C]) run(resolvedStartBlock bstream.BlockRef, stopBlock uint
 }
 
 func (p *BlockPoller[C]) processBlock(currentState *cursor, block *pbbstream.Block) (uint64, *string, error) {
-	p.logger.Info("processing block", zap.Stringer("block", block.AsRef()), zap.Uint64("lib_num", block.LibNum), zap.Bool("keep", false))
+	p.logger.Debug("processing block", zap.Stringer("block", block.AsRef()), zap.Uint64("lib_num", block.LibNum), zap.Bool("keep", false))
 	if block.Number < p.forkDB.LIBNum() {
 		panic(fmt.Errorf("unexpected error block %d is below the current LIB num %d. There should be no re-org above the current LIB num", block.Number, p.forkDB.LIBNum()))
 	}
@@ -333,7 +333,7 @@ func (p *BlockPoller[C]) loadNextBlocks(requestedBlock uint64, numberOfBlockToFe
 
 		//only fetch block if it is available on chain
 		if p.blockFetcher.IsBlockAvailable(b) {
-			p.logger.Info("optimistically fetching block", zap.Uint64("block_num", b))
+			p.logger.Debug("optimistically fetching block", zap.Uint64("block_num", b))
 			didTriggerFetch = true
 			nailer.Push(ctx, b)
 		} else {
@@ -362,7 +362,7 @@ func (p *BlockPoller[C]) loadNextBlocks(requestedBlock uint64, numberOfBlockToFe
 }
 
 func (p *BlockPoller[C]) requestBlock(blockNumber uint64, numberOfBlockToFetch int) (*BlockItem, error) {
-	p.logger.Info("requesting block", zap.Uint64("block_num", blockNumber), zap.Bool("keep", false))
+	p.logger.Debug("requesting block", zap.Uint64("block_num", blockNumber), zap.Bool("keep", false))
 
 	lastLog := time.Time{}
 	for {
@@ -395,7 +395,7 @@ func (p *BlockPoller[C]) requestBlock(blockNumber uint64, numberOfBlockToFetch i
 			continue
 		}
 
-		p.logger.Info("block was optimistically polled", zap.Uint64("block_num", blockNumber), zap.Bool("keep", false))
+		p.logger.Debug("block was optimistically polled", zap.Uint64("block_num", blockNumber), zap.Bool("keep", false))
 		return blockItem, nil
 	}
 
@@ -407,7 +407,7 @@ type FetchResponse struct {
 }
 
 func (p *BlockPoller[C]) fetchBlockWithHash(blkNum uint64, hash string) (*pbbstream.Block, error) {
-	p.logger.Info("fetching block with hash", zap.Uint64("block_num", blkNum), zap.String("hash", hash))
+	p.logger.Debug("fetching block with hash", zap.Uint64("block_num", blkNum), zap.String("hash", hash))
 	_ = hash //todo: hash will be used to fetch block from  cache
 
 	p.optimisticallyPolledBlocksLock.Lock()

--- a/blockpoller/state_file.go
+++ b/blockpoller/state_file.go
@@ -104,7 +104,7 @@ func (p *BlockPoller[C]) saveState(blocks []*forkable.Block) error {
 		return fmt.Errorf("unable to open cursor file %s: %w", fpath, err)
 	}
 
-	p.logger.Info("saved cursor",
+	p.logger.Debug("saved cursor",
 		zap.Reflect("filepath", fpath),
 		zap.Stringer("last_fired_block", sf.LastFiredBlock),
 		zap.Stringer("lib", sf.Lib),

--- a/merger/merger.go
+++ b/merger/merger.go
@@ -244,7 +244,7 @@ func (m *Merger) run() error {
 			if obf.Num > m.bundler.baseBlockNum && !m.bundler.forkable.Linkable(obf.ToBstreamBlock()) {
 				unlinkableCount++
 				if unlinkableCount > maxUnlinkableBlocks {
-					m.logger.Info("too many unlinkable blocks, continuing to next loop", zap.Uint64("base", obf.Num), zap.Int("unlinkable_count", unlinkableCount), zap.Stringer("last_seen_block", obf))
+					m.logger.Warn("too many unlinkable blocks, continuing to next loop", zap.Uint64("base", obf.Num), zap.Int("unlinkable_count", unlinkableCount), zap.Stringer("last_seen_block", obf))
 					return errCheckLoop // we have too many unlinkable blocks, continue to next loop in case
 				}
 			}
@@ -255,7 +255,7 @@ func (m *Merger) run() error {
 		case nil:
 			consecutiveErrors = 0
 		case errCheckLoop:
-			continue
+			// not an error, the walk was cut short on purpose; still subject to the polling delay below
 		case errTerminating:
 			return nil
 		case ErrStopBlockReached:
@@ -270,7 +270,11 @@ func (m *Merger) run() error {
 		}
 
 		if spentTime := time.Since(now); spentTime < m.timeBetweenPolling {
-			time.Sleep(m.timeBetweenPolling - spentTime)
+			select {
+			case <-m.Terminating():
+				return nil
+			case <-time.After(m.timeBetweenPolling - spentTime):
+			}
 		}
 	}
 }

--- a/merger/merger_run_test.go
+++ b/merger/merger_run_test.go
@@ -212,6 +212,66 @@ func TestMergerRun_HoleInOneBlockFiles_TriggersCheckLoop(t *testing.T) {
 	assert.GreaterOrEqual(t, walkCallCount, 2, "expected multiple walk calls: errCheckLoop should cause retries, not shutdown")
 }
 
+// TestMergerRun_CheckLoopRespectsPollingDelay verifies that a walk cut short by
+// errCheckLoop waits timeBetweenPolling before the next walk, like any other
+// iteration, instead of re-walking immediately.
+func TestMergerRun_CheckLoopRespectsPollingDelay(t *testing.T) {
+	const bundleSize = uint64(10) // maxUnlinkableBlocks = 40
+	const delay = 20 * time.Millisecond
+
+	var allBlocks []*bstream.OneBlockFile
+	allBlocks = append(allBlocks, buildChain(10, 19, nil)...)
+	allBlocks = append(allBlocks, buildChain(61, 120, nil)...) // 41+ unlinkable, trips errCheckLoop
+
+	walkCallCount := 0
+	checkLoopCount := 0
+	var merger *Merger
+
+	testIO := &TestMergerIO{
+		NextBundleFunc: func(_ context.Context, lowestBaseBlock uint64) (uint64, bstream.BlockRef, error) {
+			if lowestBaseBlock < 10 {
+				return 10, libRef(9), nil
+			}
+			return lowestBaseBlock, nil, nil
+		},
+		WalkOneBlockFilesFunc: func(_ context.Context, inclusiveLowerBlock uint64, callback func(*bstream.OneBlockFile) error) error {
+			walkCallCount++
+			if walkCallCount > 3 {
+				merger.Shutdown(nil)
+				return nil
+			}
+			for _, blk := range allBlocks {
+				if blk.Num < inclusiveLowerBlock {
+					continue
+				}
+				if err := callback(blk); err != nil {
+					if errors.Is(err, errCheckLoop) {
+						checkLoopCount++
+					}
+					return err
+				}
+			}
+			return nil
+		},
+		MergeAndStoreFunc: func(_ context.Context, _ uint64, _ []*bstream.OneBlockFile) error {
+			return nil
+		},
+	}
+
+	merger = newRunTestMerger(testIO, 0, bundleSize, 1)
+	merger.timeBetweenPolling = delay
+
+	start := time.Now()
+	err := merger.run()
+	require.NoError(t, err)
+	merger.bundler.WaitForMerges()
+
+	// walks 1 to 3 each end with errCheckLoop, so at least 3 delays must have elapsed
+	assert.GreaterOrEqual(t, walkCallCount, 4)
+	assert.Equal(t, 3, checkLoopCount, "fixture must trip errCheckLoop on every full walk")
+	assert.GreaterOrEqual(t, time.Since(start), 3*delay, "errCheckLoop must not skip the polling delay")
+}
+
 // TestMergerRun_MaxUnlinkableBlocksEnvOverride verifies that MERGER_MAX_UNLINKABLE_BLOCKS
 // raises the maxUnlinkableBlocks circuit breaker above its bundleSize*4 default, letting the
 // merger walk through a gap that would otherwise trip errCheckLoop — same gap as


### PR DESCRIPTION
Demotes the block poller's per-block lines from Info to Debug (about 11 per block on reader nodes, roughly 2.5 GB/day on injective), and fixes the merger's errCheckLoop path, which skipped the polling delay and re-walked immediately: both dummy-testnet mergers were logging the unlinkable-blocks line about 12 times a second. That wait is now interruptible by shutdown and the line moved to Warn. Regression test added, it fails on develop.

Worth validating before merge: some of the demoted poller lines may be ones you rely on when debugging a reader. Nothing in this repo depends on them, but if any are load-bearing for you, tell me which and I will keep them at Info.