### PR TITLE
Bump substreams, dstore and bstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,23 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
   stream now ends with `Unavailable` like a full-block stream does, so the client reconnects elsewhere. It used to
   stay open but silent, then send an undo signal at each block boundary naming a block the client had never
   received. An undo signal is also no longer sent for partial-block state whose outputs were never sent.
+- Bumped substreams: `substreams-tier1` no longer closes the squasher's cached stores while a squash is still
+  running. When the scheduler stopped early (a tier2 job failed, or the pod was shutting down), the in-flight merge
+  could panic the process or write an empty full store to storage.
 
 ### Changed
 
 - Regenerated well-known protobuf descriptors from the Buf Schema Registry. The Cosmos block model (`sf.cosmos.type.v2.Block`) now includes CometBFT v1 consensus params (`abci`, `synchrony`, `feature`), a `bls12381` public-key variant, and a local `Int64Value` for feature heights, which were previously unknown fields.
 - Bumped `bstream` to enable parallel one-blocks downloading upon bootstrap or reconnect (very useful on fast chains)
+- Bumped substreams: `substreams-tier1` squashes store partials in runs of up to 1000 segments or 30 s of work per
+  command instead of one segment per command, which capped squashing at about 15 segments per minute on busy
+  backprocessing requests. Segments whose partials are all empty get a copy of the previous full store instead of a
+  merge, server-side on object stores that support it.
+- Bumped substreams: `substreams-tier1` asks the relayer for every block from its own LIB when it connects or
+  reconnects, instead of the last 2 blocks, so a gap left by a disconnect is filled from the relayer's memory rather
+  than from the one-block store.
+- Bumped `dstore`: S3 `CopyObject` is done server-side (multipart above 5 GiB) instead of downloading and uploading
+  the object back, falling back to the old behaviour on backends answering `NotImplemented` or `MethodNotAllowed`.
 
 - Block poller per-block lines (`about to fetch block`, `requesting block`, `optimistically fetching block`, `block was optimistically polled`, `fetching block with hash`, `processing block`, `saved cursor`) are now logged at `Debug`; they fired several times per block at `Info`.
 - Removed the `--reader-node-firehose-compression` flag. It has never had any effect: the connection to the upstream endpoint always uses zstd. Operators setting it must drop it, as an unknown flag stops the process from starting.

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
-	github.com/streamingfast/bstream v0.0.2-0.20260910200824-037a10c6149b
+	github.com/streamingfast/bstream v0.0.2-0.20260910212213-07a378ae0f74
 	github.com/streamingfast/cli v0.0.4-0.20250815192146-d8a233ec3d0b
 	github.com/streamingfast/dauth v0.0.0-20260318230957-4ab1e1d2ebc3
 	github.com/streamingfast/dbin v0.9.1-0.20231117225723-59790c798e2c
@@ -34,13 +34,13 @@ require (
 	github.com/streamingfast/dmetering v0.0.0-20260901152443-1ff4cd0d617d
 	github.com/streamingfast/dmetrics v0.0.0-20260819172634-28069dc8018a
 	github.com/streamingfast/dsession v0.0.0-20260414190543-79b9846e7c58
-	github.com/streamingfast/dstore v0.2.4-0.20260825160629-56e87480522c
+	github.com/streamingfast/dstore v0.2.4-0.20260911133316-3b0685e87595
 	github.com/streamingfast/firehose-networks v0.2.3
 	github.com/streamingfast/logging v1.2.3-0.20260810132752-360563ac68a9
 	github.com/streamingfast/payment-gateway v0.0.0-20260527144655-d0576d2a4ee3
 	github.com/streamingfast/pbgo v0.0.6-0.20260206150405-2b95acf70437
 	github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0
-	github.com/streamingfast/substreams v1.22.1-0.20260908190533-360e41fbc42f
+	github.com/streamingfast/substreams v1.22.1-0.20260911133942-1b7d09c2de7b
 	github.com/stretchr/testify v1.12.1
 	github.com/test-go/testify v1.1.4
 	github.com/testcontainers/testcontainers-go v0.44.0

--- a/go.sum
+++ b/go.sum
@@ -2287,8 +2287,8 @@ github.com/spf13/viper v1.21.0/go.mod h1:P0lhsswPGWD/1lZJ9ny3fYnVqxiegrlNrEmgLjb
 github.com/spiffe/go-spiffe/v2 v2.7.0 h1:uXe1MflJoHw58wAUvxVlcM7WpKtijWG7I1UidcGh6g4=
 github.com/spiffe/go-spiffe/v2 v2.7.0/go.mod h1:47Q0Q9/AqGha8QLHp+kxpH4Wca7X7EnOtlIJy3mxZ3U=
 github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
-github.com/streamingfast/bstream v0.0.2-0.20260910200824-037a10c6149b h1:adnWk6foHegfzOh0TJs0fRchNEmZNKSZXJr1Ymz3wuI=
-github.com/streamingfast/bstream v0.0.2-0.20260910200824-037a10c6149b/go.mod h1:Asuul2Rnxln0Vk6eY869AZ2UybIQcB7eYOQAIhfQHzE=
+github.com/streamingfast/bstream v0.0.2-0.20260910212213-07a378ae0f74 h1:0Dy392LW8ed46HJDbXjc+J8WI57w3MWGloaKlxzXYGg=
+github.com/streamingfast/bstream v0.0.2-0.20260910212213-07a378ae0f74/go.mod h1:Asuul2Rnxln0Vk6eY869AZ2UybIQcB7eYOQAIhfQHzE=
 github.com/streamingfast/cli v0.0.4-0.20250815192146-d8a233ec3d0b h1:ztYeX3/5rg2tV2EU7edcrcHzMz6wUbdJB+LqCrP5W8s=
 github.com/streamingfast/cli v0.0.4-0.20250815192146-d8a233ec3d0b/go.mod h1:o9R/tjNON01X2mgWL5qirl2MV6xQ4EZI5D504ST3K/M=
 github.com/streamingfast/dauth v0.0.0-20260318230957-4ab1e1d2ebc3 h1:Zo2daSGDUPoK32w9G1e9fZO3Q6b5Cvu5ZojdoD/Wgp8=
@@ -2311,8 +2311,8 @@ github.com/streamingfast/dregistry v0.0.0-20260818204944-2fed3956d4e1 h1:keuutoe
 github.com/streamingfast/dregistry v0.0.0-20260818204944-2fed3956d4e1/go.mod h1:vfsE+IinxWwS89Zu7KdQAizkF+INgG9x/7V++Aeum6A=
 github.com/streamingfast/dsession v0.0.0-20260414190543-79b9846e7c58 h1:at7VPRhGImEz71Tr7I6Wtql9KSxQhKBAPkCDyuEIO9g=
 github.com/streamingfast/dsession v0.0.0-20260414190543-79b9846e7c58/go.mod h1:ldDwFqr20xXyaLhwDm7XlMaf2vvoZNOrjgsMcFJGtrw=
-github.com/streamingfast/dstore v0.2.4-0.20260825160629-56e87480522c h1:GURTlIajYhrQvk8dIYPLTa9urVaghe8fUCb/V+6qeVk=
-github.com/streamingfast/dstore v0.2.4-0.20260825160629-56e87480522c/go.mod h1:TMunfchUOefhTu+X2a81fPMW0F4/cGNNdihXIaChpJI=
+github.com/streamingfast/dstore v0.2.4-0.20260911133316-3b0685e87595 h1:6g0nr+xLX8H19ISrZgwzlo+tiqxuPxPvylzEF3UEs7c=
+github.com/streamingfast/dstore v0.2.4-0.20260911133316-3b0685e87595/go.mod h1:t5131zzb5Kw3/x4ssBOCxr4FSPvBn8F2hdTgYZcFsfw=
 github.com/streamingfast/dtracing v0.0.0-20260303163312-862cb0fb60c9 h1:RaMv0J2e30vQpJiKdWOGB1HObWtJ4/w4vEUkUhTYE+c=
 github.com/streamingfast/dtracing v0.0.0-20260303163312-862cb0fb60c9/go.mod h1:huOJyjMYS6K8upTuxDxaNd+emD65RrXoVBvh8f1/7Ns=
 github.com/streamingfast/dummy-blockchain v1.7.7 h1:9IZk0zmkeqHirSIRSNtbxrl5kRzyoS7kmXGqKuFI2Yc=
@@ -2346,8 +2346,8 @@ github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAt
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0 h1:Y15G1Z4fpEdm2b+/70owI7TLuXadlqBtGM7rk4Hxrzk=
 github.com/streamingfast/snapshotter v0.0.0-20230316190750-5bcadfde44d0/go.mod h1:/Rnz2TJvaShjUct0scZ9kKV2Jr9/+KBAoWy4UMYxgv4=
-github.com/streamingfast/substreams v1.22.1-0.20260908190533-360e41fbc42f h1:XITgRK5HWF0D13jHiHYP/Rt7ArhVYK7ik74wQAMPUuw=
-github.com/streamingfast/substreams v1.22.1-0.20260908190533-360e41fbc42f/go.mod h1:IcDTsh454VcFzcahrpBildjJDUankkty+PGtEQ+ysqA=
+github.com/streamingfast/substreams v1.22.1-0.20260911133942-1b7d09c2de7b h1:P/r70zIWXFQA/5xciL74fqmb04qlJH3mr1usdTUBVHA=
+github.com/streamingfast/substreams v1.22.1-0.20260911133942-1b7d09c2de7b/go.mod h1:vIstFZJj7RRIXv9+wv1dvF9O34Rzk1XraR0g1rN25xg=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed h1:LU6/c376zP1cMAo9L6rFLyjo0W7RU+hIh7BegH8Zo5M=
 github.com/streamingfast/wazero v0.0.0-20241202185309-91287c3640ed/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/streamingfast/worker-pool-protocol v0.0.0-20251029142144-b539534f3eb1 h1:aoPCoeTHwCQbzRwLBpT45GUvZgAzevIUBgPZjJzBbug=


### PR DESCRIPTION
- substreams (#932, #935, #925): tier1 squashes store partials in runs and copies the full store over empty partials; fixes a race closing the squasher's stores mid-squash; tier1 reconnects to the relayer from its LIB.
- dstore (#49): S3 `CopyObject` is done server-side.
- bstream (#67): merged version of the parallel one-block download already on develop.